### PR TITLE
temporarily include DemoEventHub for getting started guide

### DIFF
--- a/cutlass-libraries/sdk/libs/javascript/thirdparty/caplin-br/br/DemoEventHub.js
+++ b/cutlass-libraries/sdk/libs/javascript/thirdparty/caplin-br/br/DemoEventHub.js
@@ -1,0 +1,34 @@
+define("br/DemoEventHub", /** @exports br/DemoEventHub */ function(require, module, exports) {
+  "use strict";
+  
+  var br = require( 'br' );
+  var ServiceRegistry = require( './ServiceRegistry' );
+
+  // TODO: work out why 'Emitter' should be used here rather than 'emitter'
+  var Emitter = require( 'Emitter' );
+
+  var DemoEventHub = function() {
+    this.channels = {};
+  };
+   
+  DemoEventHub.prototype.channel = function( channel ) {
+    if ( !this.channels[ channel ] ) {
+      this.channels[channel] = new DemoEmitter(channel);
+    }
+   
+    return this.channels[ channel ];
+  }
+
+  var DemoEmitter = function(name) {
+    this.name = name;
+  };
+  br.extend( DemoEmitter, Emitter );
+
+  DemoEmitter.prototype.trigger = function() {
+    console.log( 'trigger', this.name, arguments );
+    Emitter.prototype.trigger.apply( this, arguments );
+  };
+
+  module.exports = DemoEventHub;
+
+});

--- a/cutlass-sdk/sdk-includes/templates/aspect-template/index.html
+++ b/cutlass-sdk/sdk-includes/templates/aspect-template/index.html
@@ -6,13 +6,24 @@
 		<title>My Application</title>
 		
 		<@css.bundle theme="standard"@/>
-		<@js.bundle@/>
 		
-		<script>
-			var oApp = new @appns.App();
-		</script>
 	</head>
 	<body>
 		@SUCCESS.MESSAGE.JNDI.TOKEN@
+
+		<@js.bundle@/>
+		<script>
+			( function() {
+
+				caplin.thirdparty('br-caplin');
+
+				var ServiceRegistry = require( 'br/ServiceRegistry' );
+				var DemoEventHub = require( 'br/DemoEventHub' );
+				ServiceRegistry.registerService( 'demo-event-hub', new DemoEventHub() );
+			
+				var oApp = new @appns.App();
+				
+			} )();
+		</script>
 	</body>
 </html>

--- a/cutlass-sdk/sdk-includes/templates/workbench-template/index.html
+++ b/cutlass-sdk/sdk-includes/templates/workbench-template/index.html
@@ -7,6 +7,12 @@
 		<@js.bundle@/>
 		
 		<script type="text/javascript">
+			caplin.thirdparty('br-caplin');
+
+			var ServiceRegistry = require( 'br/ServiceRegistry' );
+			var DemoEventHub = require( 'br/DemoEventHub' );
+			ServiceRegistry.registerService( 'demo-event-hub', new DemoEventHub() );
+
 			var oWorkbench;
 			
 			function initialize()


### PR DESCRIPTION
- Temp `DemoEventHub`
- Update Aspect and Workbench .html templates to add `DemoEventHub` to the `ServiceRegistry` accessible via `demo-event-hub` alias
- Moved script to the bottom of `<body>` in the aspect. I'm used to `document.body` being available in JS and this fixes it. Just a preference really.
