### PR TITLE
fix Linux firefox command args so that it's now possible to start a new

### DIFF
--- a/cutlass-sdk/build-resources/test-runner.conf
+++ b/cutlass-sdk/build-resources/test-runner.conf
@@ -24,5 +24,5 @@ browserPaths:
   linux:
     chrome: ../../build/browsers/chrome-linux/chrome$$--incognito$$--user-data-dir=../../build/browsers/profile/chromium
     chromedriver: ../../build/browsers/chromedriver
-    firefox: ../../build/browsers/firefox-linux-21.0/firefox$$-private$$-profile$$../../build/browsers/profile/firefox
+    firefox: ../../build/browsers/firefox-linux-21.0/firefox$$-private$$-profile$$../../build/browsers/profile/firefox$$--no-remote
     firefox-webdriver: ../../build/browsers/firefox-linux-12.0/firefox$$-private$$-private$$-profile$$../../build/browsers/profile/firefox


### PR DESCRIPTION
Firefox browser instance at the start of the test, and close it at the
end of the test -- it still leaves the test runner around after the end
of the tests if there was already an active Firefox instance before the
tests were run.
