### PR TITLE
changes to log store so error logs must always be asserted in a spec test

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/LogMessageStore.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/LogMessageStore.java
@@ -152,7 +152,8 @@ public class LogMessageStore
 			System.out.println(String.format(message, params));
 		}
 		
-		if (storeLogs)
+		boolean isFatalOrErrorLog = (messages == fatalMessages) || (messages == errorMessages);
+		if (storeLogs || isFatalOrErrorLog)
 		{
 			messages.add(new LogMessage(message, params));
 		}

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/aspect/AspectTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/aspect/AspectTest.java
@@ -3,6 +3,7 @@ package org.bladerunnerjs.spec.aspect;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Aspect;
 import org.bladerunnerjs.model.NamedDirNode;
+import org.bladerunnerjs.model.engine.AbstractNode;
 import org.bladerunnerjs.model.events.NodeReadyEvent;
 import org.bladerunnerjs.model.exception.name.InvalidDirectoryNameException;
 import org.bladerunnerjs.specutil.engine.SpecTest;
@@ -61,6 +62,7 @@ public class AspectTest extends SpecTest {
 	@Test
 	public void invalidAspectNameSpaceThrowsException() throws Exception {
 		when(badAspect).create();
-		then(exceptions).verifyException(InvalidDirectoryNameException.class, badAspect.dir(), unquoted("'!#*'") );
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Aspect", badAspect.dir())
+			.and(exceptions).verifyException(InvalidDirectoryNameException.class, badAspect.dir(), unquoted("'!#*'") );
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/blade/BladeTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/blade/BladeTest.java
@@ -5,6 +5,7 @@ import org.bladerunnerjs.model.Aspect;
 import org.bladerunnerjs.model.Blade;
 import org.bladerunnerjs.model.Bladeset;
 import org.bladerunnerjs.model.NamedDirNode;
+import org.bladerunnerjs.model.engine.AbstractNode;
 import org.bladerunnerjs.model.events.NodeReadyEvent;
 import org.bladerunnerjs.model.exception.name.InvalidDirectoryNameException;
 import org.bladerunnerjs.model.exception.name.InvalidPackageNameException;
@@ -57,13 +58,15 @@ public class BladeTest extends SpecTest {
 	@Test
 	public void invalidBladeNameSpaceThrowsException() throws Exception {
 		when(bladeWithInvalidName).populate();
-		then(exceptions).verifyException(InvalidDirectoryNameException.class, bladeWithInvalidName.dir(), "_-=+");
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Blade", bladeWithInvalidName.dir())
+			.and(exceptions).verifyException(InvalidDirectoryNameException.class, bladeWithInvalidName.dir(), "_-=+");
 	}
 	
 	@Test
 	public void usingJSKeywordAsBladeNameSpaceThrowsException() throws Exception {
 		when(bladeWithJSKeyWordName).populate();
-		then(exceptions).verifyException(InvalidPackageNameException.class, bladeWithJSKeyWordName.dir(), "export");
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Blade", bladeWithJSKeyWordName.dir())
+			.and(exceptions).verifyException(InvalidPackageNameException.class, bladeWithJSKeyWordName.dir(), "export");
 	}
 	@Ignore //waiting for change to default appConf values, app namespace will be set to app name
 	@Test

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/bladeset/BladesetTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/bladeset/BladesetTest.java
@@ -3,6 +3,7 @@ package org.bladerunnerjs.spec.bladeset;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Bladeset;
 import org.bladerunnerjs.model.NamedDirNode;
+import org.bladerunnerjs.model.engine.AbstractNode;
 import org.bladerunnerjs.model.events.NodeReadyEvent;
 import org.bladerunnerjs.model.exception.name.InvalidDirectoryNameException;
 import org.bladerunnerjs.model.exception.name.InvalidPackageNameException;
@@ -69,18 +70,21 @@ public class BladesetTest extends SpecTest {
 	@Test
 	public void invalidBladesetDirectoryNameSpaceThrowsException() throws Exception {
 		when(invalidBladesetName).populate();
-		then(exceptions).verifyException(InvalidDirectoryNameException.class,invalidBladesetName.dir(), "#Invalid");
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Bladeset", invalidBladesetName.dir())
+			.and(exceptions).verifyException(InvalidDirectoryNameException.class,invalidBladesetName.dir(), "#Invalid");
 	}
 	
 	@Test
 	public void usingJSKeywordAsBladesetNameSpaceThrowsException() throws Exception {
 		when(JSKeywordBladesetName).populate();
-		then(exceptions).verifyException(InvalidPackageNameException.class,JSKeywordBladesetName.dir(), "else");
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Bladeset", JSKeywordBladesetName.dir())
+			.and(exceptions).verifyException(InvalidPackageNameException.class,JSKeywordBladesetName.dir(), "else");
 	}
 	
 	@Test
 	public void invalidBladesetPackageNameSpaceThrowsException() throws Exception {
 		when(invalidPackageName).populate();
-		then(exceptions).verifyException(InvalidPackageNameException.class,invalidPackageName.dir(), "_invalid");
+		then(logging).errorMessageReceived(AbstractNode.Messages.NODE_CREATION_FAILED_LOG_MSG, "Bladeset", invalidPackageName.dir())
+			.and(exceptions).verifyException(InvalidPackageNameException.class,invalidPackageName.dir(), "_invalid");
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/command/CreateAppCommandTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/command/CreateAppCommandTest.java
@@ -116,6 +116,7 @@ public class CreateAppCommandTest extends SpecTest {
 		then(app).dirExists()
 			.and(output).containsLine(APP_CREATED_CONSOLE_MSG, app.getName())
 			.and(output).doesNotContain(APP_DEPLOYED_LOG_MSG, app.getName())
+			.and(logging).errorMessageReceived(APP_DEPLOYMENT_FAILED_LOG_MSG, app.getName(), app.dir())
 			.and(exceptions).verifyException(IllegalStateException.class, appJars.dir().getPath());
 	}
 	


### PR DESCRIPTION
I spent a good amount of time debugging tests when an assertion that no errors were logged would have helped.
I've made changes so error and fatal logs are always stored in the message store and therefor fatal and error logs must always be asserted in tests.
