### PR TITLE
Added scrollbar and min-width to workbench panels

### DIFF
--- a/cutlass-sdk/workspace/sdk/libs/javascript/caplin/resources/br/workbench/WorkbenchPanel.css
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/caplin/resources/br/workbench/WorkbenchPanel.css
@@ -96,4 +96,6 @@
 
 .workbench-panel > ul{
 	height: 100%;
+	overflow: auto;
+	min-width: 160px;
 }


### PR DESCRIPTION
- When the screen resolution is low, workbench tools often go off the
  screen and there was no scrollbar to get at them.
- When user resizes a workbench panel too small, contents of workbench
  tools get rearranged and look terrible, hence min-width.
