### PR TITLE
Use an optimistic file watcher service which naïvely assumes files have

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
@@ -116,6 +116,11 @@ public class BRJS extends AbstractBRJSRootNode
 		this(brjsDir, new SLF4JLoggerFactory(), new PrintStreamConsoleWriter(System.out));
 	}
 	
+	public BRJS(File brjsDir, LogConfiguration logConfigurator, FileModificationService fileModificationService) {
+		// TODO: what was the logConfiguration parameter going to be used for?
+		this(brjsDir, new BRJSPluginLocator(), fileModificationService, new SLF4JLoggerFactory(), new PrintStreamConsoleWriter(System.out));
+	}
+	
 	@Override
 	public boolean isRootDir(File dir)
 	{

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/OptimisticFileModificationInfo.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/OptimisticFileModificationInfo.java
@@ -1,0 +1,8 @@
+package org.bladerunnerjs.utility.filemodification;
+
+public class OptimisticFileModificationInfo implements FileModificationInfo {
+	@Override
+	public long getLastModified() {
+		return 1;
+	}
+}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/OptimisticFileModificationService.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/OptimisticFileModificationService.java
@@ -1,0 +1,22 @@
+package org.bladerunnerjs.utility.filemodification;
+
+import java.io.File;
+
+public class OptimisticFileModificationService implements FileModificationService {
+	OptimisticFileModificationInfo optimisticFileModificationInfo = new OptimisticFileModificationInfo();
+	
+	@Override
+	public void setRootDir(File rootDir) {
+		// do nothing
+	}
+	
+	@Override
+	public FileModificationInfo getModificationInfo(File file) {
+		return optimisticFileModificationInfo;
+	}
+	
+	@Override
+	public void close() {
+		// do nothing
+	}
+}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/PessimisticFileModificationInfo.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/filemodification/PessimisticFileModificationInfo.java
@@ -1,7 +1,7 @@
 package org.bladerunnerjs.utility.filemodification;
 
 public class PessimisticFileModificationInfo implements FileModificationInfo {
-	long lastModified = 0;
+	private long lastModified = 0;
 	
 	@Override
 	public long getLastModified() {

--- a/js-test-driver-bundler-plugin/src/main/java/com/caplin/jstestdriver/plugin/CutlassBundleInjectorPlugin.java
+++ b/js-test-driver-bundler-plugin/src/main/java/com/caplin/jstestdriver/plugin/CutlassBundleInjectorPlugin.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.utility.filemodification.OptimisticFileModificationService;
 import org.bladerunnerjs.appserver.BRJSThreadSafeModelAccessor;
 import org.bladerunnerjs.logger.LogLevel;
 import org.bladerunnerjs.logging.ConsoleLoggerConfigurator;
@@ -31,7 +32,7 @@ public class CutlassBundleInjectorPlugin extends AbstractModule
     			.pkg("brjs.core").logsAt(LogLevel.WARN);
     		logConfigurator.setLogLevel(LogLevel.INFO);
     		
-    		brjs = BRJSAccessor.initialize(new BRJS(new File(".").getCanonicalFile(), logConfigurator));
+    		brjs = BRJSAccessor.initialize(new BRJS(new File(".").getCanonicalFile(), logConfigurator, new OptimisticFileModificationService()));
     		BRJSThreadSafeModelAccessor.initializeModel(brjs);
 		}
 		finally


### PR DESCRIPTION
never changed while running Javascript tests rather than the default
Java 7 file watcher service -- this will slightly improve performance
on all platforms, and considerably improve performance on Windows due
to the outstanding WatchKey.close() bug, plus should work around a
threading bug in our model code that we have still yet to fix.
