### PR TITLE
Hard-coding all references to EncodingAccessor.getDefault<IO>Encoding to 'UT...

### DIFF
--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/CharacterEncodingFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/CharacterEncodingFilter.java
@@ -36,11 +36,11 @@ public class CharacterEncodingFilter implements Filter
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
 	{
-		logger.debug("setting character encoding to '" + EncodingAccessor.getDefaultOutputEncoding() + "'");
+		logger.debug("setting character encoding to 'UTF-8'");
 		
 		// TODO: this should actually only be done after the response has come back, and once we know that this is actually character
 		// stream data, but this would be too costly using the current filter set-up
-		response.setCharacterEncoding(EncodingAccessor.getDefaultOutputEncoding());
+		response.setCharacterEncoding("UTF-8");
 		chain.doFilter(request, response);
 	}
 }

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/BundlerTokenFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/BundlerTokenFilter.java
@@ -84,7 +84,7 @@ public class BundlerTokenFilter implements Filter
 					logger.debug("processing and replacing bundler tokens within response.");
 					
 					StringBuffer filteredResponse = tokenProcessor.replaceTokens(appConf, httpRequest, responseWrapper.getReader());
-					byte[] filteredData = filteredResponse.toString().getBytes(EncodingAccessor.getDefaultOutputEncoding());
+					byte[] filteredData = filteredResponse.toString().getBytes("UTF-8");
 					response.setContentLength(filteredData.length);
 					out.write(filteredData);
 				}

--- a/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundleWriterFactory.java
+++ b/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundleWriterFactory.java
@@ -6,7 +6,6 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 
-import com.caplin.cutlass.EncodingAccessor;
 import org.bladerunnerjs.model.exception.request.ContentProcessingException;
 
 public class BundleWriterFactory
@@ -17,11 +16,11 @@ public class BundleWriterFactory
 		
 		try
 		{
-			writer = new OutputStreamWriter(outputStream, EncodingAccessor.getDefaultOutputEncoding());
+			writer = new OutputStreamWriter(outputStream, "UTF-8");
 		}
 		catch (UnsupportedEncodingException e)
 		{
-			throw new ContentProcessingException(e, "'" + EncodingAccessor.getDefaultOutputEncoding() + "' is not a supported character encoding.");
+			throw new ContentProcessingException(e, "Unable to create OutputStreamWriter.");
 		}
 		
 		return writer;

--- a/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundlerFileReader.java
+++ b/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundlerFileReader.java
@@ -9,8 +9,6 @@ import java.io.PushbackInputStream;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 
-import com.caplin.cutlass.EncodingAccessor;
-
 public class BundlerFileReader extends Reader
 {
 	private boolean readStarted;
@@ -21,7 +19,7 @@ public class BundlerFileReader extends Reader
 	{
 		FileInputStream fileInputStream = new FileInputStream(file);
 		pushbackInputStream = new PushbackInputStream(fileInputStream, 3);
-		inputStreamReader = new InputStreamReader(pushbackInputStream, EncodingAccessor.getDefaultInputEncoding());
+		inputStreamReader = new InputStreamReader(pushbackInputStream, "UTF-8");
 	}
 	
 	@Override

--- a/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundlerFileReaderFactory.java
+++ b/bundlers/src/main/java/com/caplin/cutlass/bundler/io/BundlerFileReaderFactory.java
@@ -8,15 +8,13 @@ import java.io.Reader;
 
 import org.bladerunnerjs.utility.UnicodeReader;
 
-import com.caplin.cutlass.EncodingAccessor;
-
 public class BundlerFileReaderFactory
 {
 	public static Reader getBundlerFileReader(File file) throws IOException
 	{
 		FileInputStream fileInputStream = new FileInputStream(file);
 		BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream);
-		Reader bundlerFileReader = new UnicodeReader(bufferedInputStream, EncodingAccessor.getDefaultInputEncoding());
+		Reader bundlerFileReader = new UnicodeReader(bufferedInputStream, "UTF-8");
 		
 		return bundlerFileReader;
 	}

--- a/bundlers/src/main/java/com/caplin/cutlass/bundler/js/minification/UglifyMinifier.java
+++ b/bundlers/src/main/java/com/caplin/cutlass/bundler/js/minification/UglifyMinifier.java
@@ -75,7 +75,7 @@ public class UglifyMinifier implements Minifier
 		
 		for(File sourceFile : sourceFiles)
 		{
-			String sourceCode = FileUtils.readFileToString(sourceFile, EncodingAccessor.getDefaultInputEncoding());
+			String sourceCode = FileUtils.readFileToString(sourceFile, "UTF-8");
 			convertedSourceFiles.add(new SourceFile(sourceFile.getPath(), sourceCode));
 		}
 		

--- a/bundlers/src/test/java/com/caplin/cutlass/bundler/UnicodeBundlerTest.java
+++ b/bundlers/src/test/java/com/caplin/cutlass/bundler/UnicodeBundlerTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.caplin.cutlass.EncodingAccessor;
@@ -57,6 +58,7 @@ public class UnicodeBundlerTest
 		assertEquals("€", results.get("app.eurosign"));
 	}
 	
+	@Ignore // TODO we are no longer relying on the old bladerunner conf and have hard-coded this to UTF-8
 	@Test
 	public void utf8BecomesGarbledWhenInputEncodingIsLatin1() throws Exception
 	{
@@ -77,6 +79,7 @@ public class UnicodeBundlerTest
 		assertEquals("€", results.get("app.eurosign"));
 	}
 	
+	@Ignore // TODO we are no longer relying on the old bladerunner conf and have hard-coded this to UTF-8
 	@Test
 	public void outputEncodingCanBeSetToUtf16() throws Exception
 	{
@@ -87,6 +90,7 @@ public class UnicodeBundlerTest
 		assertEquals("€", results.get("app.eurosign"));
 	}
 	
+	@Ignore // TODO we are no longer relying on the old bladerunner conf and have hard-coded this to UTF-8
 	@Test(expected=JsonSyntaxException.class)
 	public void verifyOutputEncodingIsDefinitelyUtf16() throws Exception
 	{

--- a/cutlass-common/src/main/java/com/caplin/cutlass/filter/CharResponseWrapper.java
+++ b/cutlass-common/src/main/java/com/caplin/cutlass/filter/CharResponseWrapper.java
@@ -13,8 +13,6 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
-import com.caplin.cutlass.EncodingAccessor;
-
 public class CharResponseWrapper extends HttpServletResponseWrapper
 {
 	private ByteArrayOutputStream byteArrayOutputStream;
@@ -34,7 +32,7 @@ public class CharResponseWrapper extends HttpServletResponseWrapper
 				byteArrayOutputStream.write(i);
 			}
 		};
-		printWriter = new PrintWriter(new OutputStreamWriter(byteArrayOutputStream, EncodingAccessor.getDefaultOutputEncoding()));
+		printWriter = new PrintWriter(new OutputStreamWriter(byteArrayOutputStream, "UTF-8"));
 	}
 	
 	@Override
@@ -52,6 +50,6 @@ public class CharResponseWrapper extends HttpServletResponseWrapper
 	public Reader getReader() throws UnsupportedEncodingException
 	{
 		printWriter.flush();
-		return new InputStreamReader(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()), EncodingAccessor.getDefaultOutputEncoding());
+		return new InputStreamReader(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()), "UTF-8");
 	}
 }


### PR DESCRIPTION
...F-8'

We need to delete the older bladerunnerconf.java class from our codebase as well as EncodingAccessor but this is a larger piece of work and we want to ensure we port over test coverage/have it's equivelent.
@Ignoring tests which changed the legacy bladerunner.conf properties and expecting different encoding to be set

cc: @dchambers @andyberry88 
