### PR TITLE
Allow the `dep-insight -a` command to be used with partially defined

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliases/AliasesFile.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliases/AliasesFile.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.bladerunnerjs.aliasing.AliasDefinition;
+import org.bladerunnerjs.aliasing.AliasException;
 import org.bladerunnerjs.aliasing.AliasOverride;
 import org.bladerunnerjs.aliasing.AmbiguousAliasException;
 import org.bladerunnerjs.aliasing.IncompleteAliasException;
@@ -105,6 +106,43 @@ public class AliasesFile {
 		return aliasDefinition;
 	}
 	
+	public boolean hasAlias(String aliasName) throws ContentFileProcessingException {
+		boolean hasAlias = true;
+		
+		try {
+			getAlias(aliasName);
+		}
+		catch (AliasException e) {
+			hasAlias = false;
+		}
+		catch (ContentFileProcessingException e) {
+			throw e;
+		}
+		
+		return hasAlias;
+	}
+	
+	public AliasDefinition getAliasDefinition(String aliasName) throws ContentFileProcessingException, AmbiguousAliasException {
+		AliasDefinition aliasDefinition = null;
+		String scenarioName = scenarioName();
+		List<String> groupNames = groupNames();
+		
+		for(AliasDefinitionsFile aliasDefinitionsFile : bundlableNode.getAliasDefinitionFiles()) {
+			AliasDefinition nextAliasDefinition = aliasDefinitionsFile.getAliasDefinition(aliasName, scenarioName, groupNames);
+
+			if (aliasDefinition != null && nextAliasDefinition != null) {
+				throw new AmbiguousAliasException(getUnderlyingFile(), aliasName, scenarioName);
+			}
+			
+			if (nextAliasDefinition != null)
+			{
+				aliasDefinition = nextAliasDefinition;
+			}
+		}
+		
+		return aliasDefinition;
+	}
+	
 	public void write() throws IOException {
 		writer.write();
 	}
@@ -143,26 +181,5 @@ public class AliasesFile {
 		}
 		
 		return aliasOverride;
-	}
-	
-	private AliasDefinition getAliasDefinition(String aliasName) throws ContentFileProcessingException, AmbiguousAliasException {
-		AliasDefinition aliasDefinition = null;
-		String scenarioName = scenarioName();
-		List<String> groupNames = groupNames();
-		
-		for(AliasDefinitionsFile aliasDefinitionsFile : bundlableNode.getAliasDefinitionFiles()) {
-			AliasDefinition nextAliasDefinition = aliasDefinitionsFile.getAliasDefinition(aliasName, scenarioName, groupNames);
-
-			if (aliasDefinition != null && nextAliasDefinition != null) {
-				throw new AmbiguousAliasException(getUnderlyingFile(), aliasName, scenarioName);
-			}
-			
-			if (nextAliasDefinition != null)
-			{
-				aliasDefinition = nextAliasDefinition;
-			}
-		}
-		
-		return aliasDefinition;
 	}
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/deps/DependencyGraphReportBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/deps/DependencyGraphReportBuilder.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.bladerunnerjs.aliasing.AliasDefinition;
 import org.bladerunnerjs.aliasing.AliasException;
+import org.bladerunnerjs.aliasing.AliasOverride;
+import org.bladerunnerjs.aliasing.aliases.AliasesFile;
 import org.bladerunnerjs.model.Aspect;
 import org.bladerunnerjs.model.BrowsableNode;
 import org.bladerunnerjs.model.LinkedAsset;
@@ -64,9 +66,19 @@ public class DependencyGraphReportBuilder {
 	
 	public static String createReportForAlias(BrowsableNode browsableNode, String aliasName, boolean showAllDependencies) throws ModelOperationException {
 		try {
+			AliasesFile aliasesFile = browsableNode.aliasesFile();
+			List<LinkedAsset> linkedAssets = new ArrayList<>();
+			
+			if(!aliasesFile.hasAlias(aliasName)) {
+				AliasDefinition aliasDefinition = aliasesFile.getAliasDefinition(aliasName);
+				
+				if((aliasDefinition != null) && (aliasDefinition.getInterfaceName() != null)) {
+					aliasesFile.addAlias(new AliasOverride(aliasName, aliasDefinition.getInterfaceName()));
+				}
+			}
+			
 			AliasDefinition alias = browsableNode.getAlias(aliasName);
 			SourceModule sourceModule = browsableNode.getSourceModule(alias.getRequirePath());
-			List<LinkedAsset> linkedAssets = new ArrayList<>();
 			linkedAssets.add(sourceModule);
 			
 			return "Alias '" + aliasName + "' dependencies found:\n" +

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
@@ -1,5 +1,6 @@
 package org.bladerunnerjs.spec.command;
 
+import org.bladerunnerjs.aliasing.aliasdefinitions.AliasDefinitionsFile;
 import org.bladerunnerjs.aliasing.aliases.AliasesFile;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Aspect;
@@ -16,6 +17,7 @@ public class DepInsightCommandTest extends SpecTest {
 	App app;
 	Aspect aspect;
 	AliasesFile aliasesFile;
+	AliasDefinitionsFile bladeAliasDefinitionsFile;
 	
 	@Before
 	public void initTestObjects() throws Exception
@@ -27,6 +29,7 @@ public class DepInsightCommandTest extends SpecTest {
 			app = brjs.app("app");
 			aspect = app.aspect("default");
 			aliasesFile = aspect.aliasesFile();
+			bladeAliasDefinitionsFile = app.bladeset("bs").blade("b1").assetLocation("src").aliasDefinitionsFile();
 	}
 	
 	@Test
@@ -245,6 +248,21 @@ public class DepInsightCommandTest extends SpecTest {
 			"Alias 'alias ref' dependencies found:",
 			"    +--- 'default-aspect/src/appns/Class.js'",
 			"    |    \\--- 'alias!alias ref' (alias dep.)",
+			"    |    |    \\--- 'default-aspect/index.html' (seed file)");
+	}
+	
+	@Test
+	public void dependenciesCanBeShowsnForAnIncompleteAlias() throws Exception {
+		given(exceptions).arentCaught();
+		
+		given(aspect).indexPageHasAliasReferences("appns.bs.b1.alias-ref")
+			.and(aspect).hasClasses("appns.TheClass", "appns.TheInterface")
+			.and(bladeAliasDefinitionsFile).hasAlias("appns.bs.b1.alias-ref", null, "appns.TheInterface");
+		when(brjs).runCommand("dep-insight", "app", "appns.bs.b1.alias-ref", "--alias");
+		then(output).containsText(
+			"Alias 'appns.bs.b1.alias-ref' dependencies found:",
+			"    +--- 'default-aspect/src/appns/TheInterface.js'",
+			"    |    \\--- 'alias!appns.bs.b1.alias-ref' (alias dep.)",
 			"    |    |    \\--- 'default-aspect/index.html' (seed file)");
 	}
 	


### PR DESCRIPTION
aliases by pointing the alias to the interface name that we do not yet
have a concrete definition for.
