### PR TITLE
Allow quoted arguments with spaces in them when running 'brjs' from a

### DIFF
--- a/cutlass-sdk/build-resources/includes/sdk/brjs
+++ b/cutlass-sdk/build-resources/includes/sdk/brjs
@@ -5,4 +5,4 @@ JAVA_OPTS="-Xms64m -Xmx512m -XX:MaxPermSize=128M $JAVA_OPTS"
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 CUTLASS_CLASSPATH="$SCRIPT_DIR/libs/java/system/*:$SCRIPT_DIR/../conf/java/*"
 
-java $JAVA_OPTS -cp "$CUTLASS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" $@
+java $JAVA_OPTS -cp "$CUTLASS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "$@"


### PR DESCRIPTION
UNIX machine.
