### PR TITLE
Tweaked the "brjs test-server" command to print the port it's running on.

### DIFF
--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/TestRunner.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/TestRunner.java
@@ -115,7 +115,7 @@ public class TestRunner {
 			
 			try {
 				Thread.sleep(DEFAULT_SLEEP_TIME); // slight pause before we display message in case there is any browser output
-				logger.info("Server running, " + Messages.SERVER_STOP_INSTRUCTION_MESSAGE);
+				logger.info("Server running on port " + config.getPortNumber() + ", " + Messages.SERVER_STOP_INSTRUCTION_MESSAGE);
 				logger.info("");
 				
 				while(System.in.available() == 0) {


### PR DESCRIPTION
Because it's not obvious you need to point your browser at
"http://localhost:4224" (especially if you run "brjs test-server -b
none")
