### PR TITLE
We now also don't process comments when scanning the code for

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/namespacedjs/NamespacedJsSourceModule.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/namespacedjs/NamespacedJsSourceModule.java
@@ -24,6 +24,7 @@ import org.bladerunnerjs.model.exception.ModelOperationException;
 import org.bladerunnerjs.model.exception.RequirePathException;
 import org.bladerunnerjs.model.exception.UnresolvableRequirePathException;
 import org.bladerunnerjs.utility.FileModifiedChecker;
+import org.bladerunnerjs.utility.JsCommentStrippingReader;
 import org.bladerunnerjs.utility.RelativePathUtility;
 
 import com.Ostermiller.util.ConcatReader;
@@ -136,7 +137,7 @@ public class NamespacedJsSourceModule implements SourceModule {
 	}
 	
 	private void recalculateOrderedDependencies(BundlableNode bundlableNode) throws ModelOperationException {
-		try(Reader reader = getReader()) {
+		try(Reader reader = new JsCommentStrippingReader(getReader(), false)) {
 			orderDependentSourceModules = new ArrayList<>();
 			
 			StringWriter stringWriter = new StringWriter();

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/namespacedjs/NamespacedJsContentPluginTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/namespacedjs/NamespacedJsContentPluginTest.java
@@ -90,6 +90,45 @@ public class NamespacedJsContentPluginTest extends SpecTest {
 	}
 	
 	@Test
+	public void staticReferencesAreNotProcessedIfCommentedOutWithTwoSlashes() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(aspect).hasClasses("appns.Class1", "appns.Class2")
+			.and(aspect).indexPageRefersTo("appns.Class1")
+			.and(aspect).classFileHasContent("appns.Class1",
+				"appns.Class1 = function(){};\n" +
+				"// br.Core.extend(appns.Class1, appns.Class2);");
+		when(app).requestReceived("/default-aspect/namespaced-js/bundle.js", requestResponse);
+		then(requestResponse).containsClasses("appns.Class1")
+			.and(requestResponse).doesNotContainClasses("appns.Class2");
+	}
+	
+	@Test
+	public void staticReferencesAreNotProcessedIfCommentedOutWithSlashStar() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(aspect).hasClasses("appns.Class1", "appns.Class2")
+			.and(aspect).indexPageRefersTo("appns.Class1")
+			.and(aspect).classFileHasContent("appns.Class1",
+				"appns.Class1 = function(){};\n" +
+				"/* br.Core.extend(appns.Class1, appns.Class2); */");
+		when(app).requestReceived("/default-aspect/namespaced-js/bundle.js", requestResponse);
+		then(requestResponse).containsClasses("appns.Class1")
+			.and(requestResponse).doesNotContainClasses("appns.Class2");
+	}
+	
+	@Test
+	public void staticReferencesAreNotProcessedIfCommentedOutWithSlashSlashStar() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(aspect).hasClasses("appns.Class1", "appns.Class2")
+			.and(aspect).indexPageRefersTo("appns.Class1")
+			.and(aspect).classFileHasContent("appns.Class1",
+				"appns.Class1 = function(){};\n" +
+				"/** br.Core.extend(appns.Class1, appns.Class2); */");
+		when(app).requestReceived("/default-aspect/namespaced-js/bundle.js", requestResponse);
+		then(requestResponse).containsClasses("appns.Class1")
+			.and(requestResponse).doesNotContainClasses("appns.Class2");
+	}
+	
+	@Test
 	public void thePackageDefinitionsBlockShouldContainSinglePackageIfThereIsOneTopLevelClass() throws Exception {
 		given(aspect).hasNamespacedJsPackageStyle()
 			.and(aspect).hasClasses("appns.Class1")


### PR DESCRIPTION
`br.Core.extend()` and `br.Core.implement()` invocations, which use a
separate reader.
