### PR TITLE
Don't have assets include themselves in the list of dependencies they

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/TrieBasedDependenciesCalculator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/TrieBasedDependenciesCalculator.java
@@ -65,8 +65,11 @@ public class TrieBasedDependenciesCalculator
 				for(Object match : getTrie().getMatches(reader)) {
 					if (match instanceof SourceModuleReference) {
 						SourceModuleReference sourceModuleReference = (SourceModuleReference) match;
-						String dependencyRequirePath = sourceModuleReference.getRequirePath();
-						dependentSourceModules.add( assetLocation.sourceModule(dependencyRequirePath) );
+						SourceModule sourceModule = assetLocation.sourceModule(sourceModuleReference.getRequirePath());
+						
+						if(sourceModule != asset) {
+							dependentSourceModules.add(sourceModule);
+						}
 					}
 					else if (match instanceof AliasReference){
 						AliasReference aliasReference = (AliasReference) match;


### PR DESCRIPTION
have -- I was unable to replicate this within our spec tests, but this
issue was causing an exception when I ran `./brjs dep-insight app
br.presenter-component -a` on the command line to diagnose why our
JavaScript tests are currently failing.
