### PR TITLE
Got rid of the concept of test source modules, and instead just returned

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BundleSet.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BundleSet.java
@@ -11,15 +11,13 @@ import org.bladerunnerjs.plugin.AssetPlugin;
 
 public class BundleSet {
 	private final List<SourceModule> sourceModules;
-	private final List<SourceModule> testSourceModules;
 	private final List<AliasDefinition> activeAliases;
 	private final List<AssetLocation> resourceLocations;
 	private BundlableNode bundlableNode;
 	
-	public BundleSet(BundlableNode bundlableNode, List<SourceModule> sourceModules, List<SourceModule> testSourceModules, List<AliasDefinition> activeAliases, List<AssetLocation> resources) {
+	public BundleSet(BundlableNode bundlableNode, List<SourceModule> sourceModules, List<AliasDefinition> activeAliases, List<AssetLocation> resources) {
 		this.bundlableNode = bundlableNode;
 		this.sourceModules = sourceModules;
-		this.testSourceModules = testSourceModules;
 		this.activeAliases = activeAliases;
 		this.resourceLocations = resources;
 	}
@@ -30,10 +28,6 @@ public class BundleSet {
 	
 	public List<SourceModule> getSourceModules() {
 		return sourceModules;
-	}
-	
-	public List<SourceModule> getTestSourceModules() {
-		return testSourceModules;
 	}
 	
 	public List<AliasDefinition> getActiveAliases() {

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BundleSetCreator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BundleSetCreator.java
@@ -18,7 +18,6 @@ public class BundleSetCreator {
 	public class Messages {
 		public static final String BUNDLABLE_NODE_HAS_NO_SEED_FILES_MSG = "%s '%s' has no seed files.";
 		public static final String BUNDLABLE_NODE_SEED_FILES_MSG = "%s '%s' contains seed files %s.";
-		public static final String BUNDLABLE_NODE_IS_TEST_PACK = "%s '%s' is a test pack, adding test source modules as seed files.";
 		public static final String APP_SOURCE_LOCATIONS_MSG = "App '%s' has source locations %s.";
 		public static final String FILE_HAS_NO_DEPENDENCIES_MSG = "File '%s' has no dependencies.";
 		public static final String FILE_DEPENDENCIES_MSG = "File '%s' depends on %s.";
@@ -40,24 +39,7 @@ public class BundleSetCreator {
 		
 		logger.debug(Messages.APP_SOURCE_LOCATIONS_MSG, bundlableNode.app().getName(), assetContainerPaths(bundlableNode.app()));
 		
-		
-		List<SourceModule> seedTestSourceModules = new ArrayList<SourceModule>();
-		if (bundlableNode instanceof TestPack)
-		{
-			TestPack testPack = (TestPack) bundlableNode;
-			logger.debug(Messages.BUNDLABLE_NODE_IS_TEST_PACK, bundlableNode.getClass().getSimpleName(), name);
-			
-			seedTestSourceModules = testPack.testSourceModules();
-			if(seedTestSourceModules.isEmpty()) {
-				logger.debug(Messages.BUNDLABLE_NODE_HAS_NO_SEED_FILES_MSG, bundlableNode.getClass().getSimpleName(), name);
-			}
-			else {
-				logger.debug(Messages.BUNDLABLE_NODE_SEED_FILES_MSG, bundlableNode.getClass().getSimpleName(), name, seedFilePaths(bundlableNode, seedTestSourceModules));
-			}
-		}
-		
 		bundleSetBuilder.addSeedFiles(seedFiles);
-		bundleSetBuilder.addTestSourceModules(seedTestSourceModules);
 		
 		return bundleSetBuilder.createBundleSet();
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/TestPack.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/TestPack.java
@@ -26,9 +26,7 @@ public class TestPack extends AbstractBundlableNode implements NamedNode
 	private AliasesFile aliasesFile;
 	private String name;
 	
-	private NodeFileModifiedChecker testSourceModulesFileModifiedChecker = new NodeFileModifiedChecker(this);
 	private NodeFileModifiedChecker sourceModulesFileModifiedChecker = new NodeFileModifiedChecker(this);
-	private List<SourceModule> testSourceModules = null;
 	private List<SourceModule> sourceModules = null;
 	
 	public TestPack(RootNode rootNode, Node parent, File dir, String name)
@@ -48,13 +46,18 @@ public class TestPack extends AbstractBundlableNode implements NamedNode
 	@Override
 	public List<LinkedAsset> getSeedFiles() 
 	{
-		return new ArrayList<LinkedAsset>( assetLocation("tests").seedResources("js") );
+		List<LinkedAsset> seedFiles = new ArrayList<>();
+		
+		for(AssetPlugin assetPlugin : (root()).plugins().assetProducers()) {
+			for(AssetLocation assetLocation : assetLocations()) {
+				if(isTestAssetLocation(assetLocation)) {
+					seedFiles.addAll(assetPlugin.getTestSourceModules(assetLocation));
+				}
+			}
+		}
+		
+		return seedFiles;
 	}
-	
-	@Override
-	public java.util.List<LinkedAsset> seedFiles() {
-		return getSeedFiles();
-	};
 	
 	@Override
 	public String requirePrefix()
@@ -145,24 +148,6 @@ public class TestPack extends AbstractBundlableNode implements NamedNode
 		}
 		
 		return sourceModules;
-	}
-	
-	public List<SourceModule> testSourceModules() {
-		if(testSourceModulesFileModifiedChecker.hasChangedSinceLastCheck() || (testSourceModules == null)) {
-			testSourceModules = new ArrayList<SourceModule>();
-			
-			for(AssetPlugin assetPlugin : (root()).plugins().assetProducers()) {
-				for (AssetLocation assetLocation : assetLocations())
-				{
-					if ( isTestAssetLocation(assetLocation) )
-					{
-						testSourceModules.addAll(assetPlugin.getTestSourceModules(assetLocation));
-					}
-				}
-			}
-		}
-		
-		return testSourceModules;
 	}
 	
 	@Override

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
@@ -28,7 +28,6 @@ import com.google.common.base.Joiner;
 public class BundleSetBuilder {
 	private static final String BOOTSTRAP_LIB_NAME = "br-bootstrap";
 	private final Set<SourceModule> sourceModules = new LinkedHashSet<>();
-	private final Set<SourceModule> testSourceModules = new LinkedHashSet<>();
 	private final Set<AliasDefinition> activeAliases = new LinkedHashSet<>();
 	private final Set<LinkedAsset> linkedAssets = new HashSet<LinkedAsset>();
 	private final Set<AssetLocation> assetLocations = new LinkedHashSet<>();
@@ -66,25 +65,12 @@ public class BundleSetBuilder {
 			}
 		}
 		
-		return new BundleSet(bundlableNode, orderSourceModules(sourceModules), new ArrayList<SourceModule>(testSourceModules), activeAliasList, resourceLocationList);
+		return new BundleSet(bundlableNode, orderSourceModules(sourceModules), activeAliasList, resourceLocationList);
 	}
 	
 	public void addSeedFiles(List<LinkedAsset> seedFiles) throws ModelOperationException {
 		for(LinkedAsset seedFile : seedFiles) {
 			addLinkedAsset(seedFile);
-		}
-	}
-	
-	public void addTestSourceModules(List<? extends SourceModule> testSourceModules) throws ModelOperationException {
-		for(SourceModule sourceModule : testSourceModules) {
-			addTestSourceModule(sourceModule);
-		}
-	}
-	
-	private void addTestSourceModule(SourceModule sourceModule) throws ModelOperationException {
-		if(testSourceModules.add(sourceModule)) {
-			activeAliases.addAll(getAliases(sourceModule.getAliasNames()));
-			addLinkedAsset(sourceModule);
 		}
 	}
 	

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/bundling/testpack/TestPackBundlingTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/bundling/testpack/TestPackBundlingTest.java
@@ -1,10 +1,7 @@
 package org.bladerunnerjs.spec.bundling.testpack;
 
-import static org.bladerunnerjs.model.BundleSetCreator.Messages.BUNDLABLE_NODE_SEED_FILES_MSG;
-
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Aspect;
-import org.bladerunnerjs.model.BundleSetCreator;
 import org.bladerunnerjs.model.TestPack;
 import org.bladerunnerjs.testing.specutility.engine.SpecTest;
 import org.junit.Before;
@@ -58,16 +55,4 @@ public class TestPackBundlingTest extends SpecTest
     		.and(aspectUTs).testRequires("pkg/test.js", "appns/Class1");
     	then(aspectUTs).bundledFilesEquals(aspect.assetLocation("src").file("appns/Class1.js"));
 	}
-	
-	@Test
-	public void weGetGoodLogMessagesForTestSeedFiles() throws Exception {
-		given(logging).enabled()
-			.and(aspect).hasNamespacedJsPackageStyle()
-    		.and(aspect).hasClasses("appns.Class1", "appns.Class2")
-    		.and(aspectUTs).testRefersTo("pkg/test.js", "appns.Class1");
-		when(aspectUTs).bundleSetGenerated();
-		then(logging).debugMessageReceived(BundleSetCreator.Messages.BUNDLABLE_NODE_IS_TEST_PACK, unquoted("TestPack"), "TEST_TECH")
-    		.and(logging).debugMessageReceived(BUNDLABLE_NODE_SEED_FILES_MSG, unquoted("TestPack"), "TEST_TECH", unquoted("'default-aspect/tests/test-unit/TEST_TECH/tests/pkg/test.js'"));
-	}
-	
 }


### PR DESCRIPTION
the test source modules as seed files, so that TestPack now properly
conforms to the BundlableNode interface, and code like the bundle-deps
command can actually work when run over a TestPack instance.
