### PR TITLE
Changed JsCommentStrippingReader so it preserves the line endings of the

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/JsCommentStrippingReader.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/JsCommentStrippingReader.java
@@ -13,8 +13,6 @@ public class JsCommentStrippingReader extends Reader
 	private char previousChar;
 	private StringBuffer overflowBuffer = new StringBuffer();
 	
-	private static final String LINE_SEP = System.getProperty("line.separator");
-	
 	public JsCommentStrippingReader(Reader sourceReader, boolean preserveJsdoc)
 	{
 		this.sourceReader = sourceReader;
@@ -126,10 +124,14 @@ public class JsCommentStrippingReader extends Reader
 					break;
 				
 				case WITHIN_SINGLE_LINE_COMMENT:
-					if(nextChar == '\n')
+					if((nextChar == '\r') || (nextChar == '\n'))
 					{
-						state = CommentStripperState.WITHIN_SOURCE;
-						charactersWritten = write(LINE_SEP, buff, offset, maxCharacters, charactersWritten);
+						if(nextChar == '\n')
+						{
+							state = CommentStripperState.WITHIN_SOURCE;
+						}
+						
+						charactersWritten = write(nextChar, buff, offset, maxCharacters, charactersWritten);
 					}
 					break;
 				


### PR DESCRIPTION
file it's processing, rather than assuming that all files on Windows
machines will have Windows line endings, and all files on UNIX machines
will have UNIX line endings. This allows us to stick with Git's default
line ending settings, that prefer UNIX line endings even on Windows
machines.
