### PR TITLE
rename br.util.EventUtility#removeEventListener to removeEventListenerById

### DIFF
--- a/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/presenter/src/br/presenter/control/selectionfield/ToggleSwitchControl.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/presenter/src/br/presenter/control/selectionfield/ToggleSwitchControl.js
@@ -156,8 +156,8 @@ br.presenter.control.selectionfield.ToggleSwitchControl.prototype._updateEnabled
 	}
 	else {
 		br.util.ElementUtility.addClassName(this.m_eElement, "disabled");
-		br.util.EventUtility.removeEventListener(this.m_nFirstClickListenerId);
-		br.util.EventUtility.removeEventListener(this.m_nSecondClickListenerId);
+		br.util.EventUtility.removeEventListenerById(this.m_nFirstClickListenerId);
+		br.util.EventUtility.removeEventListenerById(this.m_nSecondClickListenerId);
 	}
 };
 

--- a/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/util/src/br/util/EventUtility.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/util/src/br/util/EventUtility.js
@@ -79,7 +79,7 @@ br.util.EventUtility.addEventListener = function(oTargetElem, sEvent, fEventList
  *
  * @param {int} nUniqueListenerId The event Listener Id that was returned by the method {@link #addEventListener}.
  */
-br.util.EventUtility.removeEventListener = function(nUniqueListenerId)
+br.util.EventUtility.removeEventListenerById = function(nUniqueListenerId)
 {
 	br.util.EventUtility._initMap();
 	
@@ -186,7 +186,7 @@ br.util.EventUtility._handlePageUnload = function()
 	// remove all the event handler registered with addEventListener()
 	for (nUniqueListenerId in br.util.EventUtility.m_mEvents)
 	{
-		br.util.EventUtility.removeEventListener(nUniqueListenerId);
+		br.util.EventUtility.removeEventListenerById(nUniqueListenerId);
 	}
 
 	// remove the unload event listener that caused this callback


### PR DESCRIPTION
This change brigs it back in line with CT and has been discussed and confirmed by @james-shaw-turner
