### PR TITLE
Allow property strings containing new lines to be handled by the i18n

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/i18n/I18nAssetFile.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/i18n/I18nAssetFile.java
@@ -100,7 +100,7 @@ public class I18nAssetFile implements Asset
 		{
 			assetLocation().assertIdentifierCorrectlyNamespaced(property);
 			String value = i18nProperties.getProperty(property);
-			propertiesMap.put(property, value);
+			propertiesMap.put(property, value.replaceAll("\n", "\\\\n"));
 		}
 
 		return propertiesMap;

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
@@ -243,4 +243,18 @@ public class I18nContentPluginTest extends SpecTest
 						"\"appns.p3\":\"v3\"\n"+
 				"}];");
 	}
+	
+	@Test
+	public void newLinesWithinPropertiesArePreserved() throws Exception 
+	{
+		given(app).hasBeenCreated()
+			.and(aspect).hasBeenCreated()
+			.and(aspect).containsEmptyFile("index.html")
+			.and(aspect).containsFileWithContents("resources/en.properties", "appns.p1=v\\n1");
+		when(app).requestReceived("/default-aspect/i18n/en_GB.js", response);
+		then(response).textEquals(	
+				"window._brjsI18nProperties = [{\n"+
+						"\"appns.p1\":\"v\\n1\"\n"+
+				"}];");
+	}
 }


### PR DESCRIPTION
content plug-in (see #448).
