### PR TITLE
Add test version of XMLResourceService

### DIFF
--- a/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/br/resources/aliasDefinitions.xml
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/br/resources/aliasDefinitions.xml
@@ -4,7 +4,9 @@
 		<scenario name="dev" class="br.services.JSTDHtmlResourceService" />
 	</alias>
 	<alias name="br.event-hub" defaultClass="br.EventHub"/>
-	<alias 	name="br.xml-service" defaultClass="br.services.BRXmlResourceService" />
+	<alias 	name="br.xml-service" defaultClass="br.services.BRXmlResourceService">
+		<scenario name="dev" class="br.services.JSTDXmlResourceService" />
+	</alias>
 
 	<alias name="br.presenter-component" defaultClass="br.presenter.PresenterComponentFactory" />
 	<alias name="br.date-picker" defaultClass="br.presenter.control.datefield.JQueryDatePickerControl" />

--- a/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/services/src/br/services/JSTDXmlResourceService.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/br-libs/services/src/br/services/JSTDXmlResourceService.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var br = require('br/Core');
+var BRXmlResourceService = require('./BRXmlResourceService');
+
+/**
+ * @constructor
+ * @class
+ * This class provides access to XML documents loaded via the XML bundler for testing purposes.
+ *
+ * @param {String} sUrl A URL to load XML from.
+ *
+ * @implements br.services.BRXmlResourceService
+ */
+function JSTDXmlResourceService(sUrl) {
+	var sDefaultUrl = (window.jstestdriver) ? "/test/bundles/xml.bundle" : null;
+	BRXmlResourceService.call(this, sUrl || sDefaultUrl);
+}
+
+br.extend(JSTDXmlResourceService, BRXmlResourceService);
+
+module.exports = JSTDXmlResourceService;


### PR DESCRIPTION
It was missing which caused our tests to fail as they couldn't load the
XML resources.

Note that it uses the old URL (xml.bundle instead of bundle.xml). This
is after discussing with @sospirited ... he said you guys will change it
to the correct URL once he verifies that BRJS is backwardly compatibale
in this regard.
