### PR TITLE
Memoize the result of NodeList.list(). Since this requires a real root

### DIFF
--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/BladerunnerFilters.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/BladerunnerFilters.java
@@ -17,6 +17,7 @@ import com.caplin.cutlass.ServletModelAccessor;
 import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.filter.bundlerfilter.contenttype.BundlerContentTypeFilter;
 import com.caplin.cutlass.filter.sectionfilter.SectionRedirectFilter;
@@ -39,12 +40,17 @@ public class BladerunnerFilters implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		logger = brjs.logger(LoggerType.FILTER, SectionRedirectFilter.class);
-		
-		for (Filter filter : filters)
-		{
-			filter.init(filterConfig);
+		try {
+			BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			logger = brjs.logger(LoggerType.FILTER, SectionRedirectFilter.class);
+			
+			for (Filter filter : filters)
+			{
+				filter.init(filterConfig);
+			}
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
 		}
 	}
 	

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/CharacterEncodingFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/CharacterEncodingFilter.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletResponse;
 import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.ServletModelAccessor;
 
@@ -22,8 +23,13 @@ public class CharacterEncodingFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		logger = brjs.logger(LoggerType.FILTER, CharacterEncodingFilter.class);
+		try {
+			BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			logger = brjs.logger(LoggerType.FILTER, CharacterEncodingFilter.class);
+		}
+		catch(InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/BundlerTokenFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/BundlerTokenFilter.java
@@ -22,6 +22,7 @@ import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.request.MalformedRequestException;
 
 import com.caplin.cutlass.CutlassConfig;
@@ -50,9 +51,14 @@ public class BundlerTokenFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		servletContext = filterConfig.getServletContext();
-		logger = brjs.logger(LoggerType.FILTER, BundlerTokenFilter.class);
+		try {
+			brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			servletContext = filterConfig.getServletContext();
+			logger = brjs.logger(LoggerType.FILTER, BundlerTokenFilter.class);
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/contenttype/BundlerContentTypeFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/bundlerfilter/contenttype/BundlerContentTypeFilter.java
@@ -24,6 +24,7 @@ import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.CutlassConfig;
 import com.caplin.cutlass.filter.CharResponseWrapper;
@@ -58,9 +59,14 @@ public class BundlerContentTypeFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		servletContext = filterConfig.getServletContext();
-		logger = brjs.logger(LoggerType.BUNDLER, BundlerContentTypeFilter.class);
+		try {
+			brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			servletContext = filterConfig.getServletContext();
+			logger = brjs.logger(LoggerType.BUNDLER, BundlerContentTypeFilter.class);
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/sectionfilter/SectionRedirectFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/sectionfilter/SectionRedirectFilter.java
@@ -19,6 +19,7 @@ import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.CutlassConfig;
 
@@ -33,10 +34,15 @@ public class SectionRedirectFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		servletContext = filterConfig.getServletContext();
-		contextDir = new File(servletContext.getRealPath("/"));
-		logger = brjs.logger(LoggerType.FILTER, SectionRedirectFilter.class);
+		try {
+			brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			servletContext = filterConfig.getServletContext();
+			contextDir = new File(servletContext.getRealPath("/"));
+			logger = brjs.logger(LoggerType.FILTER, SectionRedirectFilter.class);
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/tokenfilter/TokenisingServletFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/tokenfilter/TokenisingServletFilter.java
@@ -19,6 +19,7 @@ import org.bladerunnerjs.appserver.CharResponseWrapper;
 import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.ServletModelAccessor;
 
@@ -49,11 +50,16 @@ public class TokenisingServletFilter implements Filter
 	}
 
 	@Override
-	public void init(FilterConfig filterConfig)
+	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		contextPath = filterConfig.getServletContext().getContextPath();
-		logger = brjs.logger(LoggerType.FILTER, TokenisingServletFilter.class);
+		try {
+			BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			contextPath = filterConfig.getServletContext().getContextPath();
+			logger = brjs.logger(LoggerType.FILTER, TokenisingServletFilter.class);
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/versionfilter/VersionRedirectFilter.java
+++ b/bladerunner-common-servlets/src/main/java/com/caplin/cutlass/filter/versionfilter/VersionRedirectFilter.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.CutlassConfig;
 import com.caplin.cutlass.ServletModelAccessor;
@@ -49,8 +50,13 @@ public class VersionRedirectFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		servletContext = filterConfig.getServletContext();
+		try {
+			brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			servletContext = filterConfig.getServletContext();
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/bladerunner-prod-servlets/src/main/java/com/caplin/cutlass/filter/BladerunnerProdFilters.java
+++ b/bladerunner-prod-servlets/src/main/java/com/caplin/cutlass/filter/BladerunnerProdFilters.java
@@ -17,6 +17,7 @@ import com.caplin.cutlass.ServletModelAccessor;
 import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.filter.production.GZipContentEncodingFilter;
 import com.caplin.cutlass.filter.production.ValidRequestForBundledResourceFilter;
@@ -46,12 +47,17 @@ public class BladerunnerProdFilters implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		logger = brjs.logger(LoggerType.SERVLET, BladerunnerProdFilters.class);
-		
-		for (Filter filter : filters)
-		{
-			filter.init(filterConfig);
+		try {
+			BRJS brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			logger = brjs.logger(LoggerType.SERVLET, BladerunnerProdFilters.class);
+			
+			for (Filter filter : filters)
+			{
+				filter.init(filterConfig);
+			}
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
 		}
 	}
 

--- a/bladerunner-prod-servlets/src/main/java/com/caplin/cutlass/filter/production/GZipContentEncodingFilter.java
+++ b/bladerunner-prod-servlets/src/main/java/com/caplin/cutlass/filter/production/GZipContentEncodingFilter.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.ServletModelAccessor;
 
@@ -26,8 +27,13 @@ public class GZipContentEncodingFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
-		servletContext = filterConfig.getServletContext();
+		try {
+			brjs = ServletModelAccessor.initializeAndGetModel(filterConfig.getServletContext());
+			servletContext = filterConfig.getServletContext();
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServlet.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServlet.java
@@ -15,6 +15,7 @@ import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
 import org.bladerunnerjs.model.BundlableNode;
 import org.bladerunnerjs.model.exception.ConfigException;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.model.exception.request.MalformedRequestException;
 import org.bladerunnerjs.model.exception.request.ResourceNotFoundException;
@@ -34,7 +35,12 @@ public class BRJSServlet extends HttpServlet
 		super.init(config);
 		
 		servletContext = config.getServletContext();
-		BRJSThreadSafeModelAccessor.initializeModel(servletContext);
+		try {
+			BRJSThreadSafeModelAccessor.initializeModel(servletContext);
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 		
 		try {
 			brjs = BRJSThreadSafeModelAccessor.aquireModel();

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletFilter.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletFilter.java
@@ -29,6 +29,7 @@ import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BladerunnerUri;
 import org.bladerunnerjs.model.BrowsableNode;
 import org.bladerunnerjs.model.RequestMode;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.plugin.ContentPlugin;
 
 import com.google.common.base.Joiner;
@@ -44,23 +45,28 @@ public class BRJSServletFilter implements Filter
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException
 	{
-		servletContext = filterConfig.getServletContext();
-		BRJSThreadSafeModelAccessor.initializeModel(servletContext);
-		
 		try {
-			brjs = BRJSThreadSafeModelAccessor.aquireModel();
-			List<String> pluginRequestPrefixes = new ArrayList<>();
+			servletContext = filterConfig.getServletContext();
+			BRJSThreadSafeModelAccessor.initializeModel(servletContext);
 			
-			app = brjs.locateAncestorNodeOfClass(new File(servletContext.getRealPath(".")), App.class);
-			
-			for(ContentPlugin  contentPlugin : brjs.plugins().contentProviders()) {
-				pluginRequestPrefixes.add(contentPlugin.getRequestPrefix());
+			try {
+				brjs = BRJSThreadSafeModelAccessor.aquireModel();
+				List<String> pluginRequestPrefixes = new ArrayList<>();
+				
+				app = brjs.locateAncestorNodeOfClass(new File(servletContext.getRealPath(".")), App.class);
+				
+				for(ContentPlugin  contentPlugin : brjs.plugins().contentProviders()) {
+					pluginRequestPrefixes.add(contentPlugin.getRequestPrefix());
+				}
+				
+				contentPluginPrefixPattern = Pattern.compile("^.*/([a-zA-Z0-9_-]+-aspect|workbench)/" + "(" + Joiner.on("|").join(pluginRequestPrefixes) + ")(/.*)?$");
 			}
-			
-			contentPluginPrefixPattern = Pattern.compile("^.*/([a-zA-Z0-9_-]+-aspect|workbench)/" + "(" + Joiner.on("|").join(pluginRequestPrefixes) + ")(/.*)?$");
+			finally {
+				BRJSThreadSafeModelAccessor.releaseModel();
+			}
 		}
-		finally {
-			BRJSThreadSafeModelAccessor.releaseModel();
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
 		}
 	}
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSThreadSafeModelAccessor.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSThreadSafeModelAccessor.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletContext;
 
 import org.bladerunnerjs.logging.NullLogConfigurator;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 /**
  * A utility class so Servlets and Filters can share a single BRJS model instance.
@@ -20,11 +21,11 @@ public class BRJSThreadSafeModelAccessor {
 	protected static BRJS model;
 	private static final ReentrantLock lock = new ReentrantLock();
 	
-	public static synchronized void initializeModel(ServletContext servletContext) {
+	public static synchronized void initializeModel(ServletContext servletContext) throws InvalidSdkDirectoryException {
 		initializeModel( new File(servletContext.getRealPath("/")) );
 	}
 	
-	public static synchronized void initializeModel(File path) {
+	public static synchronized void initializeModel(File path) throws InvalidSdkDirectoryException {
 		if(model == null) {
 			model = new BRJS(path, new NullLogConfigurator());
 		}

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractBRJSRootNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractBRJSRootNode.java
@@ -7,11 +7,12 @@ import javax.naming.InvalidNameException;
 import org.bladerunnerjs.console.ConsoleWriter;
 import org.bladerunnerjs.logging.LoggerFactory;
 import org.bladerunnerjs.model.engine.AbstractRootNode;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.modelupdate.ModelUpdateException;
 
 
 public abstract class AbstractBRJSRootNode extends AbstractRootNode implements BRJSNode {
-	public AbstractBRJSRootNode(File dir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) {
+	public AbstractBRJSRootNode(File dir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) throws InvalidSdkDirectoryException {
 		super(dir, loggerFactory, consoleWriter);
 	}
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
@@ -21,6 +21,7 @@ import org.bladerunnerjs.model.engine.Node;
 import org.bladerunnerjs.model.engine.NodeItem;
 import org.bladerunnerjs.model.engine.NodeList;
 import org.bladerunnerjs.model.exception.ConfigException;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.command.CommandArgumentsException;
 import org.bladerunnerjs.model.exception.command.CommandOperationException;
 import org.bladerunnerjs.model.exception.command.NoSuchCommandException;
@@ -78,14 +79,12 @@ public class BRJS extends AbstractBRJSRootNode
 	private final File libsDir = file("sdk/libs/javascript");
 	private boolean closed = false;
 	
-	public BRJS(File brjsDir, PluginLocator pluginLocator, FileModificationService fileModificationService, LoggerFactory loggerFactory, ConsoleWriter consoleWriter)
+	public BRJS(File brjsDir, PluginLocator pluginLocator, FileModificationService fileModificationService, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) throws InvalidSdkDirectoryException
 	{
 		super(brjsDir, loggerFactory, consoleWriter);
 		this.workingDir = new WorkingDirNode(this, brjsDir);
 		
-		if(dir != null) {
-			fileModificationService.setRootDir(dir);
-		}
+		fileModificationService.setRootDir(dir);
 		
 		this.fileModificationService = fileModificationService;
 		
@@ -104,21 +103,21 @@ public class BRJS extends AbstractBRJSRootNode
 		commandList = new CommandList(this, pluginLocator.getCommandPlugins());
 	}
 
-	public BRJS(File brjsDir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) {
+	public BRJS(File brjsDir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) throws InvalidSdkDirectoryException {
 		this(brjsDir, new BRJSPluginLocator(), new Java7FileModificationService(loggerFactory), loggerFactory, consoleWriter);
 	}
 	
-	public BRJS(File brjsDir, FileModificationService fileModificationService) {
+	public BRJS(File brjsDir, FileModificationService fileModificationService) throws InvalidSdkDirectoryException {
 		this(brjsDir, new BRJSPluginLocator(), fileModificationService, new SLF4JLoggerFactory(), new PrintStreamConsoleWriter(System.out));
 	}
 	
-	public BRJS(File brjsDir, LogConfiguration logConfiguration)
+	public BRJS(File brjsDir, LogConfiguration logConfiguration) throws InvalidSdkDirectoryException
 	{
 		// TODO: what was the logConfiguration parameter going to be used for?
 		this(brjsDir, new SLF4JLoggerFactory(), new PrintStreamConsoleWriter(System.out));
 	}
 	
-	public BRJS(File brjsDir, LogConfiguration logConfigurator, FileModificationService fileModificationService) {
+	public BRJS(File brjsDir, LogConfiguration logConfigurator, FileModificationService fileModificationService) throws InvalidSdkDirectoryException {
 		// TODO: what was the logConfiguration parameter going to be used for?
 		this(brjsDir, new BRJSPluginLocator(), fileModificationService, new SLF4JLoggerFactory(), new PrintStreamConsoleWriter(System.out));
 	}
@@ -366,6 +365,10 @@ public class BRJS extends AbstractBRJSRootNode
 	}
 	
 	public FileInfo getFileInfo(File file) {
+		if(file == null) {
+			System.out.println("bingo!");
+		}
+		
 		String filePath = file.getPath();
 		
 		if(!fileInfos.containsKey(filePath)) {

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
@@ -10,21 +10,34 @@ import org.bladerunnerjs.console.PrintStreamConsoleWriter;
 import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerFactory;
 import org.bladerunnerjs.logging.LoggerType;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.NodeAlreadyRegisteredException;
 
 
 public abstract class AbstractRootNode extends AbstractNode implements RootNode
 {
+	// TODO: remove this flag once we delete all old BladerRunner code
+	public static boolean allowInvalidRootDirectories = true;
+	
 	private Map<String, Node> nodeCache = new HashMap<>();
 	private LoggerFactory loggerFactory;
 	private ConsoleWriter consoleWriter;
 	
-	public AbstractRootNode(File dir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter)
+	public AbstractRootNode(File dir, LoggerFactory loggerFactory, ConsoleWriter consoleWriter) throws InvalidSdkDirectoryException
 	{
 		super();
 		
 		File rootDir = locateRootDir(dir);
-		this.dir = (rootDir == null) ? null : new File(getNormalizedPath(rootDir));
+		
+		if(rootDir == null) {
+			if(!allowInvalidRootDirectories) {
+				throw new InvalidSdkDirectoryException("'" + dir.getPath() + "' is not a valid SDK directory");
+			}
+			
+			rootDir = dir;
+		}
+		
+		this.dir = new File(getNormalizedPath(rootDir));
 		this.loggerFactory = loggerFactory;
 		this.consoleWriter = consoleWriter;
 		

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/engine/NodeList.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/engine/NodeList.java
@@ -8,11 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.bladerunnerjs.memoization.MemoizedValue;
+
 public class NodeList<N extends Node> {
 	private final Node node;
 	private final Class<N> nodeClass;
 	private final Map<String, N> namedNodes = new HashMap<>();
 	private final List<NamedNodeLocator> namedNodeLocators = new ArrayList<>();
+	private MemoizedValue<List<N>> list;
 	
 	public NodeList(Node node, Class<N> nodeClass, String subDirPath, String dirNameFilter)
 	{
@@ -48,13 +51,19 @@ public class NodeList<N extends Node> {
 	}
 	
 	public List<N> list() {
-		List<N> childList = new ArrayList<>();
-		
-		for (String nodeName : getLogicalNodeNames()) {
-			childList.add(item(nodeName));
+		if(list == null) {
+			list = new MemoizedValue<>("NodeList.list", node.root(), node.dir());
 		}
 		
-		return childList;
+		return list.value(() -> {
+			List<N> childList = new ArrayList<>();
+			
+			for (String nodeName : getLogicalNodeNames()) {
+				childList.add(item(nodeName));
+			}
+			
+			return childList;
+		});
 	}
 	
 	private List<String> getLogicalNodeNames()

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/exception/InvalidSdkDirectoryException.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/exception/InvalidSdkDirectoryException.java
@@ -1,0 +1,9 @@
+package org.bladerunnerjs.model.exception;
+
+public class InvalidSdkDirectoryException extends Exception {
+	private static final long serialVersionUID = 1L;
+	
+	public InvalidSdkDirectoryException(String msg) {
+		super(msg);
+	}
+}

--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTest.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTest.java
@@ -24,6 +24,7 @@ import org.bladerunnerjs.model.TestPack;
 import org.bladerunnerjs.model.Workbench;
 import org.bladerunnerjs.model.engine.NamedNode;
 import org.bladerunnerjs.model.engine.NodeProperties;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.plugin.ContentPlugin;
 import org.bladerunnerjs.plugin.EventObserver;
 import org.bladerunnerjs.testing.specutility.AppBuilder;
@@ -119,12 +120,12 @@ public abstract class SpecTest
 		}
 	}
 	
-	public BRJS createModel() 
+	public BRJS createModel() throws InvalidSdkDirectoryException 
 	{	
 		return new BRJS(testSdkDirectory, pluginLocator, new PessimisticFileModificationService(), new TestLoggerFactory(logging), new ConsoleStoreWriter(output));
 	}
 	
-	public BRJS createNonTestModel() {
+	public BRJS createNonTestModel() throws InvalidSdkDirectoryException {
 		return new BRJS(testSdkDirectory, new TestLoggerFactory(logging), new ConsoleStoreWriter(output));
 	}
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/BRJSTestFactory.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/BRJSTestFactory.java
@@ -5,24 +5,25 @@ import java.io.File;
 import org.bladerunnerjs.logging.LoggerFactory;
 import org.bladerunnerjs.logging.SLF4JLoggerFactory;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.plugin.PluginLocator;
 import org.bladerunnerjs.utility.filemodification.PessimisticFileModificationService;
 
 public class BRJSTestFactory {
 	
-	public static BRJS createBRJS(File brjsDir, PluginLocator pluginLocator, LoggerFactory loggerFactory) {
+	public static BRJS createBRJS(File brjsDir, PluginLocator pluginLocator, LoggerFactory loggerFactory) throws InvalidSdkDirectoryException {
 		return new BRJS(brjsDir, pluginLocator, new PessimisticFileModificationService(), loggerFactory, new StubConsoleWriter());
 	}
 	
-	public static BRJS createBRJS(File brjsDir, PluginLocator pluginLocator) {
+	public static BRJS createBRJS(File brjsDir, PluginLocator pluginLocator) throws InvalidSdkDirectoryException {
 		return new BRJS(brjsDir, pluginLocator, new PessimisticFileModificationService(), new SLF4JLoggerFactory(), new StubConsoleWriter());
 	}
 
-	public static BRJS createBRJS(File brjsDir, LoggerFactory loggerFactory) {
+	public static BRJS createBRJS(File brjsDir, LoggerFactory loggerFactory) throws InvalidSdkDirectoryException {
 		return createBRJS(brjsDir, new MockPluginLocator(), loggerFactory);
 	}
 	
-	public static BRJS createBRJS(File brjsDir) {
+	public static BRJS createBRJS(File brjsDir) throws InvalidSdkDirectoryException {
 		return createBRJS(brjsDir, new SLF4JLoggerFactory());
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/memoization/MemoizedValueTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/memoization/MemoizedValueTest.java
@@ -26,7 +26,7 @@ public class MemoizedValueTest {
 	private FileInfo watchFileInfo;
 	
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() throws Exception {
 		tempDir = FileUtility.createTemporaryDirectory(MemoizedValueTest.class.getSimpleName());
 		watchFile = new File(tempDir, "watch-file");
 		sdkDir = new File(tempDir, "sdk");

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/AppNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/AppNavigationTest.java
@@ -20,7 +20,7 @@ public class AppNavigationTest
 
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		app = brjs.app("a1");

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/AspectNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/AspectNavigationTest.java
@@ -17,7 +17,7 @@ public class AspectNavigationTest
 	private BRJS brjs;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		aspect = brjs.app("a1").aspect("a1");

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/BRJSNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/BRJSNavigationTest.java
@@ -24,7 +24,7 @@ public class BRJSNavigationTest
 	private BRJS brjs;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(testBase);
 		nodeTesterFactory = new NodeTesterFactory<>(brjs, BRJS.class);

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/BRJSUnitTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/BRJSUnitTest.java
@@ -3,8 +3,6 @@ package org.bladerunnerjs.model;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
-
 import org.bladerunnerjs.testing.utility.BRJSTestFactory;
 import org.bladerunnerjs.utility.FileUtility;
 import org.junit.After;
@@ -17,7 +15,7 @@ public class BRJSUnitTest
 	private BRJS brjs;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		File rootDir = FileUtility.createTemporaryDirectory( this.getClass().getCanonicalName() );
 		new File(rootDir, "sdk").mkdir();

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/BladeNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/BladeNavigationTest.java
@@ -18,7 +18,7 @@ public class BladeNavigationTest
 	private Blade blade;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		blade = brjs.app("a1").bladeset("bs1").blade("b1");

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/BladesetNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/BladesetNavigationTest.java
@@ -18,7 +18,7 @@ public class BladesetNavigationTest
 	private Bladeset bladeset;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		bladeset = brjs.app("a1").bladeset("bs1");

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/TestPackNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/TestPackNavigationTest.java
@@ -16,7 +16,7 @@ public class TestPackNavigationTest
 	private NodeTesterFactory<TestPack> nodeTesterFactory;
 	
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		technologyTestPack = brjs.app("a1").bladeset("bs1").testType("type1").testTech("tech1");
 		nodeTesterFactory = new NodeTesterFactory<>(technologyTestPack, TestPack.class);

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/TypedTestPackNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/TypedTestPackNavigationTest.java
@@ -16,7 +16,7 @@ public class TypedTestPackNavigationTest
 	private NodeTesterFactory<TypedTestPack> nodeTesterFactory;
 	
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		typedTestPack = brjs.app("a1").bladeset("bs1").testType("type1");
 		nodeTesterFactory = new NodeTesterFactory<>(typedTestPack, TypedTestPack.class);

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/WorkbenchNavigationTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/WorkbenchNavigationTest.java
@@ -17,7 +17,7 @@ public class WorkbenchNavigationTest
 	private Workbench workbench;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"));
 		workbench = brjs.app("a1").bladeset("bs1").blade("b1").workbench();

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/engine/NodeTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/engine/NodeTest.java
@@ -27,7 +27,7 @@ public class NodeTest
 	private RootNode mockRootNode = new MockRootNode();
 	
 	@Test
-	public void rootNodeIsReturned()
+	public void rootNodeIsReturned() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode midNode = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path" ) );
@@ -216,7 +216,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateAncestorNodeOfClassShouldSucceedTheImmediateAncestorIsARootNode()
+	public void locateAncestorNodeOfClassShouldSucceedTheImmediateAncestorIsARootNode() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		File childDir = new File(rootNode.dir(), "child-1");
@@ -226,7 +226,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateAncestorNodeOfClassShouldSucceedIfOneOfTheAncestorsIsARootNode()
+	public void locateAncestorNodeOfClassShouldSucceedIfOneOfTheAncestorsIsARootNode() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		File grandchildDir = new File(TEST_DIR, "root/child-1/grandchild/1");
@@ -236,7 +236,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateAncestorNodeOfClassShouldSucceedIfOneOfTheDistantAncestorsIsARootNode()
+	public void locateAncestorNodeOfClassShouldSucceedIfOneOfTheDistantAncestorsIsARootNode() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		File greatGrandchildDir = new File(TEST_DIR, "root/child-1/grandchild/1/2-greatgrandchild");
@@ -246,7 +246,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateAncestorNodeOfClassShouldReturnNullIfNoneOfTheAncestorsAreRootNodes()
+	public void locateAncestorNodeOfClassShouldReturnNullIfNoneOfTheAncestorsAreRootNodes() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		File rootParent = new File(TEST_DIR).getParentFile();
@@ -255,7 +255,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateFirstAncestorNodeShouldWorkIfGivenTheNodesActualDir()
+	public void locateFirstAncestorNodeShouldWorkIfGivenTheNodesActualDir() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		
@@ -263,7 +263,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateFirstAncestorNodeShouldWorkIfGivenAChildDir()
+	public void locateFirstAncestorNodeShouldWorkIfGivenAChildDir() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		
@@ -271,7 +271,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateFirstAncestorNodeShouldWorkIfGivenAGrandChildDir()
+	public void locateFirstAncestorNodeShouldWorkIfGivenAGrandChildDir() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		
@@ -279,7 +279,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void locateFirstAncestorNodeShouldReturnNullIfGivenAParentDir()
+	public void locateFirstAncestorNodeShouldReturnNullIfGivenAParentDir() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		
@@ -287,7 +287,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void requestingANonExistentChildWorks()
+	public void requestingANonExistentChildWorks() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		TestChildNode childNode = rootNode.childNode("non-existent");
@@ -296,7 +296,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void requestingAnExistentChildWorks()
+	public void requestingAnExistentChildWorks() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		TestChildNode childNode = rootNode.childNode("1");
@@ -305,7 +305,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void theNameOfANonExistentChildNodeIsCorrect()
+	public void theNameOfANonExistentChildNodeIsCorrect() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		TestChildNode childNode = rootNode.childNode("non-existent");
@@ -314,7 +314,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void theNameOfAnExistentChildNodeIsCorrect()
+	public void theNameOfAnExistentChildNodeIsCorrect() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		TestChildNode childNode = rootNode.childNode("1");
@@ -323,7 +323,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void requestingAllChildrenWorks()
+	public void requestingAllChildrenWorks() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		List<TestChildNode> children = rootNode.childNodes();
@@ -334,7 +334,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void requestingAllChildrenWhenSomeOfThemAreCachedWorks()
+	public void requestingAllChildrenWhenSomeOfThemAreCachedWorks() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		TestChildNode child1 = rootNode.childNode("1");
@@ -348,7 +348,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void requestingAllChildrenDoesntReturnNonExistentItemsThatAreCached()
+	public void requestingAllChildrenDoesntReturnNonExistentItemsThatAreCached() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		rootNode.childNode("non-existent");
@@ -410,7 +410,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void newNodesArentCreatedWhenTheItemIsAlreadyCached()
+	public void newNodesArentCreatedWhenTheItemIsAlreadyCached() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode(new File(TEST_DIR, "root"));
 		Node childNode1 = rootNode.childNode("1");
@@ -680,7 +680,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void rootOutputDirShouldBeCorrect()
+	public void rootOutputDirShouldBeCorrect() throws Exception
 	{
 		File rootDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode(rootDir);
@@ -689,7 +689,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void childOutputDirShouldBeCorrect()
+	public void childOutputDirShouldBeCorrect() throws Exception
 	{
 		File rootDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode(rootDir);
@@ -698,7 +698,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void namedChildOutputDirShouldBeCorrect()
+	public void namedChildOutputDirShouldBeCorrect() throws Exception
 	{
 		File rootDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode(rootDir);
@@ -707,7 +707,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void nestedChildOutputDirsShouldBeCorrect()
+	public void nestedChildOutputDirsShouldBeCorrect() throws Exception
 	{
 		File rootDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode(rootDir);
@@ -716,7 +716,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void outputDirWithChildNodeAndPluginNameShouldBeCorrect()
+	public void outputDirWithChildNodeAndPluginNameShouldBeCorrect() throws Exception
 	{
 		File rootDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode(rootDir);
@@ -725,7 +725,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void observersGetNotifiedOnReady()
+	public void observersGetNotifiedOnReady() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		EventObserver observer = mock(EventObserver.class);
@@ -737,7 +737,7 @@ public class NodeTest
 	}
 
 	@Test
-	public void multipleObserversGetNotifiedOnReady()
+	public void multipleObserversGetNotifiedOnReady() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		EventObserver observer1 = mock(EventObserver.class);
@@ -753,7 +753,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void parentsObserversGetNotified ()
+	public void parentsObserversGetNotified() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode node = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path/to-file" ) );
@@ -766,7 +766,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void notificationsBubbleUpToParentsParent ()
+	public void notificationsBubbleUpToParentsParent() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode midNode = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path" ) );
@@ -780,7 +780,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void notificationsDontBubbleDown ()
+	public void notificationsDontBubbleDown() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode midNode = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path" ) );
@@ -798,7 +798,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void notificationsAreCalledOnCorrectObserversForLevelAndInCorrectOrder ()
+	public void notificationsAreCalledOnCorrectObserversForLevelAndInCorrectOrder() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode midNode = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path" ) );
@@ -820,7 +820,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void readyIsCalledOnInitIfDirExists ()
+	public void readyIsCalledOnInitIfDirExists() throws Exception
 	{
 		File nodeDir = new File(TEST_DIR, "root");
 		TestRootNode rootNode = new TestRootNode( nodeDir );
@@ -835,7 +835,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void readyIsNotCalledOnInitIfDirDoesntExist ()
+	public void readyIsNotCalledOnInitIfDirDoesntExist() throws Exception
 	{
 		File nodeDir = new File(TEST_DIR, "root2");
 		TestRootNode rootNode = new TestRootNode( nodeDir );
@@ -850,7 +850,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void exceptionsFromANodeObserverDoNotGetPropagatedAndAnErrorIsLogged()
+	public void exceptionsFromANodeObserverDoNotGetPropagatedAndAnErrorIsLogged() throws Exception
 	{
 		LogMessageStore logStore = new LogMessageStore(true);
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root"), new TestLoggerFactory(logStore) );
@@ -866,7 +866,7 @@ public class NodeTest
 	}
 	
 	@Test
-	public void observersOnlyGetNotifiedForCorrectEvents()
+	public void observersOnlyGetNotifiedForCorrectEvents() throws Exception
 	{
 		TestRootNode rootNode = new TestRootNode( new File(TEST_DIR, "root") );
 		TestNode midNode = new TestNode(rootNode, rootNode, new File(rootNode.dir(), "path" ) );

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/engine/TestRootNode.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/engine/TestRootNode.java
@@ -9,6 +9,7 @@ import org.bladerunnerjs.model.IO;
 import org.bladerunnerjs.model.StandardFileInfo;
 import org.bladerunnerjs.model.engine.AbstractRootNode;
 import org.bladerunnerjs.model.engine.NodeItem;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.NodeAlreadyRegisteredException;
 import org.bladerunnerjs.testing.utility.MockLoggerFactory;
 import org.bladerunnerjs.utility.filemodification.PessimisticFileModificationInfo;
@@ -22,14 +23,14 @@ public final class TestRootNode extends AbstractRootNode
 	NodeItem<TestMultiLocationItemNode> multiLocationItemNode = new NodeItem<>(this, TestMultiLocationItemNode.class, "single-item-primary-location");
 	private final IO io = new IO();
 	
-	public TestRootNode(File dir)
+	public TestRootNode(File dir) throws InvalidSdkDirectoryException
 	{
 		this(dir, new MockLoggerFactory());
 		
 		registerInitializedNode();
 	}
 	
-	public TestRootNode(File dir, LoggerFactory loggerFactory)
+	public TestRootNode(File dir, LoggerFactory loggerFactory) throws InvalidSdkDirectoryException
 	{
 		super(dir, loggerFactory, null);
 		

--- a/brjs-core/src/test/java/org/bladerunnerjs/plugin/PluginLoaderTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/plugin/PluginLoaderTest.java
@@ -27,7 +27,7 @@ public class PluginLoaderTest
 	private LogMessageStore logStore;
 
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		logStore = new LogMessageStore(true);
 		brjs = BRJSTestFactory.createBRJS(new File("src/test/resources/BRJSTest"), new TestLoggerFactory(logStore));

--- a/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
+++ b/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
@@ -3,9 +3,9 @@ package org.bladerunnerjs.runner;
 import java.io.File;
 import java.io.IOException;
 
+import org.bladerunnerjs.model.exception.command.CommandOperationException;
 import org.bladerunnerjs.runner.CommandRunner;
 import org.bladerunnerjs.runner.CommandRunner.InvalidDirectoryException;
-import org.bladerunnerjs.runner.CommandRunner.InvalidSdkDirectoryException;
 import org.bladerunnerjs.runner.CommandRunner.NoSdkArgumentException;
 
 import com.caplin.cutlass.util.FileUtility;
@@ -33,7 +33,7 @@ public class CommandRunnerTest {
 		commandRunner.run(new String[] {dir("no-such-directory")});
 	}
 	
-	@Test(expected=InvalidSdkDirectoryException.class)
+	@Test(expected=CommandOperationException.class)
 	public void anExceptionIsThrownIfTheSdkArgumentIsNotAValidSdkDirectory() throws Exception {
 		dirFile("not-a-valid-sdk-directory").mkdirs();
 		commandRunner.run(new String[] {dir("not-a-valid-sdk-directory")});

--- a/cutlass-common/src/main/java/com/caplin/cutlass/ServletModelAccessor.java
+++ b/cutlass-common/src/main/java/com/caplin/cutlass/ServletModelAccessor.java
@@ -5,14 +5,15 @@ import java.io.File;
 import javax.servlet.ServletContext;
 
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 public class ServletModelAccessor extends org.bladerunnerjs.appserver.BRJSThreadSafeModelAccessor {
-	public static BRJS initializeAndGetModel(ServletContext servletContext) {
+	public static BRJS initializeAndGetModel(ServletContext servletContext) throws InvalidSdkDirectoryException {
 		initializeModel(servletContext);
 		return BRJSAccessor.initialize(model);
 	}
 	
-	public static BRJS initializeAndGetModel(File path) {
+	public static BRJS initializeAndGetModel(File path) throws InvalidSdkDirectoryException {
 		initializeModel(path);
 		return BRJSAccessor.initialize(model);
 	}

--- a/cutlass-common/src/main/java/com/caplin/cutlass/testing/BRJSTestFactory.java
+++ b/cutlass-common/src/main/java/com/caplin/cutlass/testing/BRJSTestFactory.java
@@ -6,19 +6,20 @@ import java.io.PrintStream;
 import org.bladerunnerjs.console.PrintStreamConsoleWriter;
 import org.bladerunnerjs.logging.LoggerFactory;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.utility.filemodification.PessimisticFileModificationService;
 
 
 public class BRJSTestFactory {
-	public static BRJS createBRJS(File brjsDir, LoggerFactory loggerFactory, PrintStream printStream) {
+	public static BRJS createBRJS(File brjsDir, LoggerFactory loggerFactory, PrintStream printStream) throws InvalidSdkDirectoryException {
 		return new BRJS(brjsDir, new CommandOnlyPluginLocator(), new PessimisticFileModificationService(), loggerFactory, new PrintStreamConsoleWriter(printStream));
 	}
 	
-	public static BRJS createBRJS(File brjsDir, PrintStream printStream) {
+	public static BRJS createBRJS(File brjsDir, PrintStream printStream) throws InvalidSdkDirectoryException {
 		return new BRJS(brjsDir, new CommandOnlyPluginLocator(), new PessimisticFileModificationService(), new StubLoggerFactory(), new PrintStreamConsoleWriter(printStream));
 	}
 	
-	public static BRJS createBRJS(File brjsDir) {
+	public static BRJS createBRJS(File brjsDir) throws InvalidSdkDirectoryException {
 		return new BRJS(brjsDir, new CommandOnlyPluginLocator(), new PessimisticFileModificationService(), new StubLoggerFactory(), new StubConsoleWriter());
 	}
 }

--- a/cutlass-common/src/test/java/com/caplin/cutlass/structure/CutlassDirectoryLocatorTest.java
+++ b/cutlass-common/src/test/java/com/caplin/cutlass/structure/CutlassDirectoryLocatorTest.java
@@ -30,7 +30,7 @@ public class CutlassDirectoryLocatorTest
 	private File tempDir;
 	
 	@Before
-	public void setUp()
+	public void setUp() throws Exception
 	{
 		BRJSAccessor.initialize(BRJSTestFactory.createBRJS(new File(testBase)));
 	}

--- a/cutlass-common/src/test/java/com/caplin/cutlass/structure/NamespaceCalculatorTest.java
+++ b/cutlass-common/src/test/java/com/caplin/cutlass/structure/NamespaceCalculatorTest.java
@@ -25,7 +25,7 @@ public class NamespaceCalculatorTest
 	private static final String testBase = "src/test/resources/ExampleAppStructure";
 
 	@Before
-	public void setup() {
+	public void setup() throws Exception {
 		BRJSAccessor.initialize(BRJSTestFactory.createBRJS(new File(testBase)));
 	}
 	

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/CommandTaskTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/CommandTaskTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.bladerunnerjs.console.ConsoleWriter;
@@ -30,7 +28,7 @@ public class CommandTaskTest
 	protected ConsoleWriter out;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		commandTask = new DummyCommandTask(mock(File.class), "test");
 	}

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/bladerunner/ServeCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/bladerunner/ServeCommandTest.java
@@ -3,8 +3,6 @@ package com.caplin.cutlass.command.bladerunner;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -25,7 +23,7 @@ public class ServeCommandTest extends CommandTaskTest
 	private BRJS brjs;
 
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		mockAppServer = mock(ApplicationServer.class);
 		when(mockAppServer.getPort()).thenReturn(1234);

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/copy/CopyBladesetCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/copy/CopyBladesetCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +25,7 @@ public class CopyBladesetCommandTest
 	private File tempSdkBaseDir, tempDir, targetBladesetDirectory, targetBladeJsFile, targetFxBladesetDirectory, targetFxBladeJsFile;
 	
 	@Before
-	public void setUp() throws IOException 
+	public void setUp() throws Exception 
 	{		
 		tempDir = FileUtility.createTemporaryDirectory("CopyBladesetCommandTest");
 		tempDir.deleteOnExit();

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateApplicationCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateApplicationCommandTest.java
@@ -3,15 +3,12 @@ package com.caplin.cutlass.command.create;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.bladerunnerjs.model.exception.command.CommandArgumentsException;
-import org.bladerunnerjs.model.exception.ConfigException;
-
 import com.caplin.cutlass.CutlassConfig;
 import com.caplin.cutlass.util.FileUtility;
 
@@ -34,7 +31,7 @@ public class CreateApplicationCommandTest
 	private File newApplicationToBeCreatedDirectory;
 	
 	@Before
-	public void setup() throws IOException, ConfigException
+	public void setup() throws Exception
 	{
 		File tempDirRoot = FileUtility.createTemporaryDirectory(this.getClass().getSimpleName());
 		FileUtils.copyDirectory(testResourcesSdkDir, tempDirRoot);

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateAspectCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateAspectCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -30,7 +29,7 @@ public class CreateAspectCommandTest
 	private CreateAspectCommand createAspectCommand;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		File tempDirRoot = FileUtility.createTemporaryDirectory(this.getClass().getSimpleName());
 		FileUtils.copyDirectory(testResourcesSdkDir, tempDirRoot);

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateBladeCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateBladeCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -32,7 +31,7 @@ public class CreateBladeCommandTest
 	private File fxBladesetBladesDirectory;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		File tempDirRoot = FileUtility.createTemporaryDirectory(this.getClass().getSimpleName());
 

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateBladesetCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateBladesetCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -31,7 +30,7 @@ public class CreateBladesetCommandTest
 	private File newBladesetToBeCreatedDirectory;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		File tempDirRoot = FileUtility.createTemporaryDirectory(this.getClass().getSimpleName());
 

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateLibraryCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/create/CreateLibraryCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintStream;
 
 import org.apache.commons.io.FileUtils;
@@ -30,7 +29,7 @@ public class CreateLibraryCommandTest
 	private BRJS brjs;
 	
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		File tempDirRoot = FileUtility.createTemporaryDirectory(this.getClass().getSimpleName());
 		FileUtils.copyDirectory(testResourcesSdkDir, tempDirRoot);

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/importing/ImportApplicationCommandTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/importing/ImportApplicationCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -17,7 +16,6 @@ import org.bladerunnerjs.model.BRJS;
 import com.caplin.cutlass.BRJSAccessor;
 import com.caplin.cutlass.testing.BRJSTestFactory;
 
-import org.bladerunnerjs.model.exception.ConfigException;
 import org.bladerunnerjs.model.exception.command.CommandOperationException;
 import org.bladerunnerjs.model.exception.command.CommandArgumentsException;
 import com.caplin.cutlass.CutlassConfig;
@@ -32,7 +30,7 @@ public class ImportApplicationCommandTest
 	private BRJS brjs;
 	
 	@Before
-	public void setUp() throws IOException, ConfigException
+	public void setUp() throws Exception
 	{
 		tempDir = FileUtility.createTemporaryDirectory("ImportCommandTest");
 		FileUtility.copyDirectoryContents(TEST_BASE, tempDir);

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/importing/RenamerTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/importing/RenamerTest.java
@@ -28,7 +28,7 @@ public class RenamerTest
 	private File applicationDir;
 
 	@Before
-	public void setup() throws IOException
+	public void setup() throws Exception
 	{
 		appsDir = createTempAppsDir(new File(TEST_BASE, CutlassConfig.APPLICATIONS_DIR));
 		applicationDir = new File(appsDir, "emptytrader");

--- a/cutlass-tasks/src/test/java/com/caplin/cutlass/command/testIntegration/IntegrationTestFinderTest.java
+++ b/cutlass-tasks/src/test/java/com/caplin/cutlass/command/testIntegration/IntegrationTestFinderTest.java
@@ -22,7 +22,7 @@ public class IntegrationTestFinderTest
 	private IntegrationTestFinder testFinder;
 	
 	@Before
-	public void setup()
+	public void setup() throws Exception
 	{
 		BRJS brjs = BRJSTestFactory.createBRJS(new File(TEST_ROOT));
 		BRJSAccessor.initialize(brjs);

--- a/cutlass-tasks/src/test/java/org/bladerunnerjs/spec/command/SpecTest.java
+++ b/cutlass-tasks/src/test/java/org/bladerunnerjs/spec/command/SpecTest.java
@@ -1,6 +1,7 @@
 package org.bladerunnerjs.spec.command;
 
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.testing.specutility.engine.ConsoleStoreWriter;
 import org.bladerunnerjs.testing.utility.TestLoggerFactory;
 import org.bladerunnerjs.utility.filemodification.PessimisticFileModificationService;
@@ -11,7 +12,7 @@ public class SpecTest extends org.bladerunnerjs.testing.specutility.engine.SpecT
 	
 	// This allows commands which don't use the model to use the spec test format
 	@Override
-	public BRJS createModel() 
+	public BRJS createModel() throws InvalidSdkDirectoryException 
 	{	
 		return BRJSAccessor.initialize(new BRJS (testSdkDirectory, pluginLocator, new PessimisticFileModificationService(), new TestLoggerFactory(logging), new ConsoleStoreWriter(output)));
 	}

--- a/system-app-servlets/src/main/java/com/caplin/cutlass/app/servlet/RestApiServlet.java
+++ b/system-app-servlets/src/main/java/com/caplin/cutlass/app/servlet/RestApiServlet.java
@@ -40,6 +40,7 @@ import org.bladerunnerjs.logging.Logger;
 import org.bladerunnerjs.logging.LoggerType;
 import org.bladerunnerjs.logging.NullLogConfigurator;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.utility.filemodification.PessimisticFileModificationService;
 
 import com.caplin.cutlass.util.FileUtility;
@@ -102,14 +103,20 @@ public class RestApiServlet extends HttpServlet
 	@Override
 	public void init(final ServletConfig config) throws ServletException
 	{
-		context = config.getServletContext();
-		
-		File contextDir = new File( context.getRealPath("/") );
-		brjs = new BRJS(contextDir, new NullLogConfigurator(), new PessimisticFileModificationService());
-		ServletModelAccessor.initializeModel( brjs );
-		
-		if (apiService == null) { apiService = new RestApiService(brjs); };
-		logger = brjs.logger(LoggerType.SERVLET, this.getClass());
+		try {
+			context = config.getServletContext();
+			
+			File contextDir = new File( context.getRealPath("/") );
+			brjs = new BRJS(contextDir, new NullLogConfigurator(), new PessimisticFileModificationService());
+			
+			ServletModelAccessor.initializeModel( brjs );
+			
+			if (apiService == null) { apiService = new RestApiService(brjs); };
+			logger = brjs.logger(LoggerType.SERVLET, this.getClass());
+		}
+		catch (InvalidSdkDirectoryException e) {
+			throw new ServletException(e);
+		}
 	}
 	
 	@Override

--- a/system-app-servlets/src/test/java/com/caplin/cutlass/app/service/RestApiServiceTest.java
+++ b/system-app-servlets/src/test/java/com/caplin/cutlass/app/service/RestApiServiceTest.java
@@ -14,10 +14,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.BRJS;
+import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 
 import com.caplin.cutlass.BRJSAccessor;
 import com.caplin.cutlass.testing.BRJSTestFactory;
-
 import com.caplin.cutlass.util.FileUtility;
 
 
@@ -34,21 +34,21 @@ public class RestApiServiceTest
 	/* get apps tests */
 	
 	@Test
-	public void testGettingApps_NoApps()
+	public void testGettingApps_NoApps() throws Exception
 	{
 		setupService(new File(NO_APPS_PATH));
 		assertEquals( "[]", service.getApps() );
 	}
 	
 	@Test
-	public void testGettingApps_SingleApp()
+	public void testGettingApps_SingleApp() throws Exception
 	{
 		setupService(new File(ONE_APP_PATH));
 		assertEquals( "[\"app1\"]", service.getApps() );
 	}
 	
 	@Test
-	public void testGettingApps_MultipleApps()
+	public void testGettingApps_MultipleApps() throws Exception
 	{
 		setupService(new File(THREE_APPS_PATH));
 		assertEquals( "[\"app1\", \"app2\", \"app3\"]", service.getApps() );
@@ -346,7 +346,7 @@ public class RestApiServiceTest
 		assertTrue(indexFile.exists());
 	}
 	
-	private void setupService(File sdkRoot)
+	private void setupService(File sdkRoot) throws InvalidSdkDirectoryException
 	{
 		BRJS brjs = BRJSTestFactory.createBRJS(sdkRoot);
 		BRJSAccessor.initialize(brjs);


### PR DESCRIPTION
directory to be used with BRJS, become tolerant of the invalid
directories passed in many of the legacy tests, and handle invalid
directories in a more formal way for the new code.
