### PR TITLE
Updated AliasDefinitionsReader to use

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliasdefinitions/AliasDefinitionsFile.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliasdefinitions/AliasDefinitionsFile.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.bladerunnerjs.aliasing.AliasDefinition;
 import org.bladerunnerjs.aliasing.AliasOverride;
 import org.bladerunnerjs.aliasing.AmbiguousAliasException;
-import org.bladerunnerjs.model.AssetContainer;
+import org.bladerunnerjs.model.AssetLocation;
 import org.bladerunnerjs.model.exception.ConfigException;
 import org.bladerunnerjs.model.exception.request.ContentFileProcessingException;
 import org.bladerunnerjs.utility.FileModifiedChecker;
@@ -22,12 +22,12 @@ public class AliasDefinitionsFile {
 	private final File file;
 	private final FileModifiedChecker fileModifiedChecker;
 	
-	public AliasDefinitionsFile(AssetContainer assetContainer, File parent, String child) {
+	public AliasDefinitionsFile(AssetLocation assetLocation, File parent, String child) {
 		try {
 			file = new File(parent, child);
 			fileModifiedChecker = new FileModifiedChecker(file);
-			reader = new AliasDefinitionsReader(data, file, assetContainer);
-			writer = new AliasDefinitionsWriter(data, file, assetContainer.root().bladerunnerConf().getDefaultFileCharacterEncoding());
+			reader = new AliasDefinitionsReader(data, file, assetLocation);
+			writer = new AliasDefinitionsWriter(data, file, assetLocation.root().bladerunnerConf().getDefaultFileCharacterEncoding());
 		}
 		catch(ConfigException e) {
 			throw new RuntimeException(e);

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractShallowAssetLocation.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractShallowAssetLocation.java
@@ -119,7 +119,7 @@ public class AbstractShallowAssetLocation extends InstantiatedBRJSNode implement
 	@Override
 	public AliasDefinitionsFile aliasDefinitionsFile() {		
 		if(aliasDefinitionsFile == null) {
-			aliasDefinitionsFile = new AliasDefinitionsFile(assetContainer, dir(), "aliasDefinitions.xml");
+			aliasDefinitionsFile = new AliasDefinitionsFile(this, dir(), "aliasDefinitions.xml");
 		}
 		
 		return aliasDefinitionsFile;

--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/brjsconformant/BRJSConformantRootAssetLocation.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/brjsconformant/BRJSConformantRootAssetLocation.java
@@ -102,7 +102,7 @@ public class BRJSConformantRootAssetLocation extends InstantiatedBRJSNode implem
 	@Override
 	public AliasDefinitionsFile aliasDefinitionsFile() {
 		if(aliasDefinitionsFile == null) {
-			aliasDefinitionsFile = new AliasDefinitionsFile(assetContainer(), dir(), "aliasDefinitions.xml");
+			aliasDefinitionsFile = new AliasDefinitionsFile(this, dir(), "aliasDefinitions.xml");
 		}
 		
 		return aliasDefinitionsFile;

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/aliasing/AliasModelTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/aliasing/AliasModelTest.java
@@ -82,14 +82,14 @@ public class AliasModelTest extends SpecTest {
 	public void aliasDefinitionsDefinedWithinBladesetsMustBeNamespaced() throws Exception {
 		given(bladesetAliasDefinitionsFile).hasAlias("the-alias", "TheClass");
 		when(aspect).retrievesAlias("the-alias");
-		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs");
+		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs.*");
 	}
 	
 	@Test
 	public void aliasDefinitionsDefinedWithinBladesMustBeNamespaced() throws Exception {
 		given(bladeAliasDefinitionsFile).hasAlias("the-alias", "TheClass");
 		when(aspect).retrievesAlias("the-alias");
-		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs.b1");
+		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs.b1.*");
 	}
 	
 	@Test
@@ -179,7 +179,7 @@ public class AliasModelTest extends SpecTest {
 			.and(bladeAliasDefinitionsFile).hasScenarioAlias("s1", "the-alias", "Class2")
 			.and(aspectAliasesFile).usesScenario("s1");
 		when(aspect).retrievesAlias("the-alias");
-		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs.b1");
+		then(exceptions).verifyException(NamespaceException.class, "the-alias", "appns.bs.b1.*");
 	}
 	
 	@Test
@@ -234,7 +234,7 @@ public class AliasModelTest extends SpecTest {
 	public void groupIdentifiersMustBeNamespaced() throws Exception {
 		given(bladeAliasDefinitionsFile).hasGroupAlias("g1", "the-alias", "TheClass");
 		when(aspect).retrievesAlias("the-alias");
-		then(exceptions).verifyException(NamespaceException.class, "g1", "appns.bs.b1");
+		then(exceptions).verifyException(NamespaceException.class, "g1", "appns.bs.b1.*");
 	}
 	
 	@Test


### PR DESCRIPTION
AssetLocation.assertIdentifierCorrectlyNamespaced() for managing
namespace assertions.
