### PR TITLE
locateFirstBundlableAncestorNode now throws an exception

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServlet.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServlet.java
@@ -19,6 +19,7 @@ import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.model.exception.request.MalformedRequestException;
 import org.bladerunnerjs.model.exception.request.ResourceNotFoundException;
+import org.bladerunnerjs.plugin.plugins.commands.standard.InvalidBundlableNodeException;
 
 
 public class BRJSServlet extends HttpServlet
@@ -75,12 +76,8 @@ public class BRJSServlet extends HttpServlet
 			response.setContentType(contentType);
 			BladerunnerUri bladerunnerUri = new BladerunnerUri(brjs, servletContext, request);
 			BundlableNode bundlableNode = app.getBundlableNode(bladerunnerUri);
-			if (bundlableNode == null)
-			{
-				throw new ResourceNotFoundException("Unable to find BundlableNode for URL " + request.getRequestURI());
-			}
 			bundlableNode.handleLogicalRequest(bladerunnerUri.logicalPath, response.getOutputStream());
-		} catch (MalformedRequestException | ResourceNotFoundException | ContentProcessingException | ConfigException e) {
+		} catch (MalformedRequestException | ResourceNotFoundException | ContentProcessingException | ConfigException | InvalidBundlableNodeException e) {
 			throw new ServletException(e);
 		}
 		finally {

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletUtils.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletUtils.java
@@ -18,6 +18,7 @@ import org.bladerunnerjs.model.exception.ModelOperationException;
 import org.bladerunnerjs.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.model.exception.request.MalformedRequestException;
 import org.bladerunnerjs.plugin.ContentPlugin;
+import org.bladerunnerjs.plugin.plugins.commands.standard.InvalidBundlableNodeException;
 import org.bladerunnerjs.utility.ContentPathParser;
 
 public class BRJSServletUtils
@@ -68,19 +69,11 @@ public class BRJSServletUtils
 			BundlableNode bundlableNode = getBundableNodeForRequest(brjs, requestUri, resp);
 			contentPlugin.writeContent(contentPath, bundlableNode.getBundleSet(), resp.getOutputStream());
 		}
-		catch (MalformedRequestException ex)
+		catch (MalformedRequestException | InvalidBundlableNodeException ex)
 		{
 			sendErrorResponse(resp, 404, ex);
 		}
-		catch (ContentProcessingException ex)
-		{
-			sendErrorResponse(resp, 500, ex);
-		}
-		catch (IOException ex)
-		{
-			sendErrorResponse(resp, 500, ex);
-		}
-		catch (ModelOperationException ex)
+		catch (ContentProcessingException | IOException | ModelOperationException ex)
 		{
 			sendErrorResponse(resp, 500, ex);
 		}
@@ -108,7 +101,7 @@ public class BRJSServletUtils
 		return app;
 	}
 	
-	public BundlableNode getBundableNodeForRequest(BRJS brjs, BladerunnerUri requestUri, HttpServletResponse resp) throws ServletException, MalformedRequestException
+	public BundlableNode getBundableNodeForRequest(BRJS brjs, BladerunnerUri requestUri, HttpServletResponse resp) throws ServletException, MalformedRequestException, InvalidBundlableNodeException
 	{
 		App app = getAppForRequest(brjs, requestUri, resp);
 		File baseDir = app.file(requestUri.scopePath);

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/App.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/App.java
@@ -20,8 +20,8 @@ import org.bladerunnerjs.model.engine.RootNode;
 import org.bladerunnerjs.model.events.AppDeployedEvent;
 import org.bladerunnerjs.model.exception.ConfigException;
 import org.bladerunnerjs.model.exception.modelupdate.ModelUpdateException;
-import org.bladerunnerjs.model.exception.request.ResourceNotFoundException;
 import org.bladerunnerjs.model.exception.template.TemplateInstallationException;
+import org.bladerunnerjs.plugin.plugins.commands.standard.InvalidBundlableNodeException;
 import org.bladerunnerjs.utility.NameValidator;
 
 
@@ -261,14 +261,10 @@ public class App extends AbstractBRJSNode implements NamedNode
 		}
 	}
 	
-	public BundlableNode getBundlableNode(BladerunnerUri bladerunnerUri) throws ResourceNotFoundException
+	public BundlableNode getBundlableNode(BladerunnerUri bladerunnerUri) throws InvalidBundlableNodeException
 	{
 		File baseDir = new File(dir(), bladerunnerUri.scopePath);
 		BundlableNode bundlableNode = root().locateFirstBundlableAncestorNode(baseDir);
-		
-		if(bundlableNode == null) {
-			throw new ResourceNotFoundException("No bundlable resource could be found above the directory '" + baseDir.getPath() + "'");
-		}
 		
 		return bundlableNode;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
@@ -27,11 +27,13 @@ import org.bladerunnerjs.model.exception.command.CommandOperationException;
 import org.bladerunnerjs.model.exception.command.NoSuchCommandException;
 import org.bladerunnerjs.model.exception.modelupdate.ModelUpdateException;
 import org.bladerunnerjs.plugin.PluginLocator;
+import org.bladerunnerjs.plugin.plugins.commands.standard.InvalidBundlableNodeException;
 import org.bladerunnerjs.plugin.utility.BRJSPluginLocator;
 import org.bladerunnerjs.plugin.utility.PluginAccessor;
 import org.bladerunnerjs.plugin.utility.command.CommandList;
 import org.bladerunnerjs.utility.CommandRunner;
 import org.bladerunnerjs.utility.PluginLocatorLogger;
+import org.bladerunnerjs.utility.RelativePathUtility;
 import org.bladerunnerjs.utility.UserCommandRunner;
 import org.bladerunnerjs.utility.VersionInfo;
 import org.bladerunnerjs.utility.filemodification.FileModificationInfo;
@@ -167,7 +169,7 @@ public class BRJS extends AbstractBRJSRootNode
 		fileModificationService.close();
 	}
 	
-	public BundlableNode locateFirstBundlableAncestorNode(File file)
+	public BundlableNode locateFirstBundlableAncestorNode(File file) throws InvalidBundlableNodeException
 	{
 		Node node = locateFirstAncestorNode(file);
 		BundlableNode bundlableNode = null;
@@ -181,6 +183,8 @@ public class BRJS extends AbstractBRJSRootNode
 			
 			node = node.parentNode();
 		}
+		
+		if (bundlableNode == null) throw new InvalidBundlableNodeException( RelativePathUtility.get(dir(), file) );
 		
 		return bundlableNode;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/commands/standard/BundleDepsCommand.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/commands/standard/BundleDepsCommand.java
@@ -58,15 +58,16 @@ public class BundleDepsCommand extends ArgsParsingCommandPlugin
 		
 		if(!bundlableDir.exists()) throw new DirectoryDoesNotExistException(relativePath, this);
 		
-		BundlableNode bundlableNode = brjs.locateFirstBundlableAncestorNode(bundlableDir);
-		
-		if(bundlableNode == null) throw new InvalidBundlableNodeException(relativePath, this);
 		
 		try {
+			BundlableNode bundlableNode = brjs.locateFirstBundlableAncestorNode(bundlableDir);
 			out.println(DependencyGraphReportBuilder.createReport(bundlableNode, showAllDependencies));
 		}
 		catch (ModelOperationException e) {
 			throw new CommandOperationException(e);
+		}
+		catch (InvalidBundlableNodeException e) {
+			throw new CommandArgumentsException(e, this);
 		}
 		return 0;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/commands/standard/InvalidBundlableNodeException.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/commands/standard/InvalidBundlableNodeException.java
@@ -1,12 +1,10 @@
 package org.bladerunnerjs.plugin.plugins.commands.standard;
 
-import org.bladerunnerjs.model.exception.command.CommandArgumentsException;
-import org.bladerunnerjs.plugin.CommandPlugin;
 
-public class InvalidBundlableNodeException extends CommandArgumentsException {
+public class InvalidBundlableNodeException extends Exception {
 	private static final long serialVersionUID = 1L;
 	
-	public InvalidBundlableNodeException(String path, CommandPlugin commandPlugin) {
-		super("The directory '" + path + "' is not itself a bundlable directory, nor resides within a bundlable directory.", commandPlugin);
+	public InvalidBundlableNodeException(String path ) {
+		super("The directory '" + path + "' is not itself a bundlable directory, nor resides within a bundlable directory.");
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/command/BundleDepsCommandTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/command/BundleDepsCommandTest.java
@@ -67,7 +67,7 @@ public class BundleDepsCommandTest extends SpecTest {
 	public void exceptionIsThrownIfABundlableNodeCantBeLocated() throws Exception {
 		given(app).hasBeenCreated();
 		when(brjs).runCommand("bundle-deps", "../apps/app");
-		then(exceptions).verifyException(InvalidBundlableNodeException.class, "../apps/app")
+		then(exceptions).verifyException(InvalidBundlableNodeException.class, "apps/app")
 			.whereTopLevelExceptionIs(CommandArgumentsException.class);
 	}
 	


### PR DESCRIPTION
refactoring locateFirstBundlableAncestorNode so if the bundlable node can't be found an exception is thrown. This check was being done by every bit of code that used the method, its now done centrally isntead.  @dchambers can you review and merge?
