### PR TITLE
Small CSS fix for the dashboard

### DIFF
--- a/cutlass-sdk/workspace/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/themes/standard/blades-box.css
+++ b/cutlass-sdk/workspace/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/themes/standard/blades-box.css
@@ -8,6 +8,7 @@
 	height: auto;
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 10px;
 	border-style: solid;
 	border-width: 2px;
 	z-index: 1;


### PR DESCRIPTION
I've added some bottom margin to the `bladeset` box as it was sticking to the bottom of the page if you had a lot of bladesets&blades.

Before:
![image](https://cloud.githubusercontent.com/assets/356488/2863016/fef131ba-d1fd-11e3-8598-be7bce48b526.png)

After:
![image](https://cloud.githubusercontent.com/assets/356488/2863017/044f25a4-d1fe-11e3-8f37-31b17dc97bc5.png)
