### PR TITLE
only allowing plugins to handle non JSP requests

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletFilter.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/BRJSServletFilter.java
@@ -93,7 +93,7 @@ public class BRJSServletFilter implements Filter
 			if(requestPath.endsWith("/index.html") || requestPath.endsWith("/index.jsp")) {
 				filterIndexPage(request, response, chain);
 			}
-			else if(contentPluginPrefixMatcher.matches()) {
+			else if (contentPluginPrefixMatcher.matches() && !requestPath.endsWith(".jsp")) {
 				request.getRequestDispatcher("/brjs" + requestPath).forward(request, response);
 			}
 			else {


### PR DESCRIPTION
changing the BRJS filter so JSP requests can't be handled by a plugin
