### PR TITLE
Prevent onPropertyChanged being triggered if both values are NaN

### DIFF
--- a/cutlass-sdk/workspace/sdk/libs/javascript/presenter/src/br/presenter/property/Property.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/presenter/src/br/presenter/property/Property.js
@@ -75,15 +75,21 @@ br.presenter.property.Property.prototype.getValue = function()
 br.presenter.property.Property.prototype._$setInternalValue = function(vValue)
 {
 	var vOldValue = this.m_vValue;
+	var bBothValuesAreNaN = false;
 	this.m_vValue = vValue;
+
+	if (typeof vOldValue === 'number' && isNaN(vOldValue) && typeof this.m_vValue === 'number' && isNaN(this.m_vValue)) {
+		bBothValuesAreNaN = true;
+	}
 
 	this.updateView(this.getFormattedValue());
 
 	this.m_oObservable.notifyObservers("onPropertyUpdated");
-	if (vOldValue !== this.m_vValue)
+	if (vOldValue !== this.m_vValue && bBothValuesAreNaN === false)
 	{
 		this.m_oObservable.notifyObservers("onPropertyChanged");
 	}
+
 	return this;
 };
 

--- a/cutlass-sdk/workspace/sdk/libs/javascript/presenter/tests/test-unit/js-test-driver/tests/br/presenter/property/PropertyTest.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/presenter/tests/test-unit/js-test-driver/tests/br/presenter/property/PropertyTest.js
@@ -147,6 +147,19 @@ PropertyTest.prototype.test_onPropertyChangedIsNeverInvokedWhenTheValueIsUpdated
 	oProperty.setValue("initial value"); // setting to the same value as before
 };
 
+PropertyTest.prototype.test_onPropertyChangedIsNotInvokedWhenTheValuesAreNaN = function()
+{
+	var oPropertyListenerMock = mock(br.presenter.property.PropertyListener);
+	oPropertyListenerMock.stubs().onPropertyUpdated();
+
+	// no listeners have been added yet, so won't be informed about 'initial value'
+	var oProperty = new br.presenter.property.WritableProperty().setValue(NaN);
+
+	oProperty.addListener(oPropertyListenerMock.proxy());
+	oPropertyListenerMock.expects(never()).onPropertyChanged();
+	oProperty.setValue(NaN); // setting to NaN again
+};
+
 PropertyTest.prototype.test_onPropertyChangedIsInvokedForAllListenersWhenTheValueChanges = function()
 {
 	var oPropertyListenerMock1 = mock(br.presenter.property.PropertyListener);


### PR DESCRIPTION
See commit for details.
