### PR TITLE
Allow 'aliases.xml' files that don't provide concrete definitions for

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliases/AliasesFile.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/aliasing/aliases/AliasesFile.java
@@ -100,7 +100,7 @@ public class AliasesFile {
 		}
 		
 		if((aliasDefinition.getClassName() == null)) {
-			throw new IncompleteAliasException(file, aliasDefinition.getName());
+			aliasDefinition = new AliasDefinition(aliasDefinition.getName(), "br.UnknownClass", aliasDefinition.getInterfaceName());
 		}
 		
 		return aliasDefinition;

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/aliasing/AliasModelTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/aliasing/AliasModelTest.java
@@ -108,10 +108,10 @@ public class AliasModelTest extends SpecTest {
 	}
 	
 	@Test
-	public void usedAliasDefinitionsMustBeMadeConcrete() throws Exception {
+	public void unspecifiedAliasDefinitionsPointToTheUnknownClass() throws Exception {
 		given(bladeAliasDefinitionsFile).hasAlias("appns.bs.b1.the-alias", null, "TheInterface");
 		when(aspect).retrievesAlias("appns.bs.b1.the-alias");
-		then(exceptions).verifyException(IncompleteAliasException.class, "appns.bs.b1.the-alias");
+		then(aspect).hasAlias("appns.bs.b1.the-alias", "br.UnknownClass", "TheInterface");
 	}
 	
 	@Test

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/command/ApplicationDepsCommandTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/command/ApplicationDepsCommandTest.java
@@ -4,6 +4,7 @@ import org.bladerunnerjs.aliasing.aliasdefinitions.AliasDefinitionsFile;
 import org.bladerunnerjs.aliasing.aliases.AliasesFile;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Aspect;
+import org.bladerunnerjs.model.SdkJsLib;
 import org.bladerunnerjs.model.exception.command.ArgumentParsingException;
 import org.bladerunnerjs.model.exception.command.CommandArgumentsException;
 import org.bladerunnerjs.model.exception.command.NodeDoesNotExistException;
@@ -18,6 +19,7 @@ public class ApplicationDepsCommandTest extends SpecTest {
 	Aspect aspect;
 	AliasesFile aliasesFile;
 	AliasDefinitionsFile bladeAliasDefinitionsFile;
+	SdkJsLib brLib;
 	
 	@Before
 	public void initTestObjects() throws Exception
@@ -30,6 +32,7 @@ public class ApplicationDepsCommandTest extends SpecTest {
 			aspect = app.aspect("default");
 			aliasesFile = aspect.aliasesFile();
 			bladeAliasDefinitionsFile = app.bladeset("bs").blade("b1").assetLocation("src").aliasDefinitionsFile();
+			brLib = brjs.sdkLib("br");
 	}
 	
 	@Test
@@ -238,7 +241,8 @@ public class ApplicationDepsCommandTest extends SpecTest {
 	
 	@Test
 	public void incompleteAliasedDependenciesAreCorrectlyDisplayed() throws Exception {
-		given(aspect).indexPageHasAliasReferences("appns.bs.b1.alias-ref")
+		given(brLib).hasClass("br/UnknownClass")
+			.and(aspect).indexPageHasAliasReferences("appns.bs.b1.alias-ref")
 			.and(bladeAliasDefinitionsFile).hasAlias("appns.bs.b1.alias-ref", null, "appns.Interface")
 			.and(aspect).hasClasses("appns/Class", "appns/Interface");
 		when(brjs).runCommand("app-deps", "app");
@@ -246,7 +250,7 @@ public class ApplicationDepsCommandTest extends SpecTest {
 			"Aspect 'default' dependencies found:",
 			"    +--- 'default-aspect/index.html' (seed file)",
 			"    |    \\--- 'alias!appns.bs.b1.alias-ref' (alias dep.)",
-			"    |    |    \\--- 'default-aspect/src/appns/Interface.js'");
+			"    |    |    \\--- '../../libs/javascript/br/src/br/UnknownClass.js'");
 	}
 	
 	@Test

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
@@ -294,12 +294,13 @@ public class DepInsightCommandTest extends SpecTest {
 	
 	@Test
 	public void dependenciesCanBeShownForAnIncompleteAliasThatIsntUsedWithinTheApp() throws Exception {
-		given(aspect).hasClass("appns/TheInterface")
+		given(brjs.sdkLib("br")).hasClass("br/UnknownClass")
+			.and(aspect).hasClass("appns/TheInterface")
 			.and(bladeAliasDefinitionsFile).hasAlias("appns.bs.b1.alias-ref", null, "appns.TheInterface");
 		when(brjs).runCommand("dep-insight", "app", "appns.bs.b1.alias-ref", "--alias");
 		then(output).containsText(
 			"Alias 'appns.bs.b1.alias-ref' dependencies found:",
-			"    +--- 'default-aspect/src/appns/TheInterface.js'",
+			"    +--- '../../libs/javascript/br/src/br/UnknownClass.js'",
 			"    |    \\--- 'alias!appns.bs.b1.alias-ref' (alias dep.)");
 	}
 	

--- a/cutlass-sdk/workspace/sdk/libs/javascript/br/src/br/UnknownClass.js
+++ b/cutlass-sdk/workspace/sdk/libs/javascript/br/src/br/UnknownClass.js
@@ -1,0 +1,6 @@
+"use strict";
+
+function UnknownClass() {
+}
+
+module.exports = UnknownClass;


### PR DESCRIPTION
aliases previously defined within an 'aliasDefinitions.xml' file.
