### PR TITLE
Errormonitor ignore fields

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/util/ErrorMonitor.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/util/ErrorMonitor.js
@@ -20,13 +20,22 @@ br.presenter.util.ErrorMonitor = function(oTooltipNode)
 	this.m_pErrorStack = [];
 };
 
+/**
+ *
+ * Filters all nodes of type {@see br.presenter.node.ToolTipField} and monitors them using
+ * {@see br.presenter.util.ErrorMonitor#monitorField}
+ *
+ * @type {<br.presenter.node.PresentationNode>[]} pGroups
+ */
 br.presenter.util.ErrorMonitor.prototype.addErrorListeners = function(pGroups)
 {
+	var node;
 	for (var i=0; i<pGroups.length; i++)
 	{
-		if(pGroups[i].hasError && pGroups[i].failureMessage)
+		node = pGroups[i];
+		if(node instanceof br.presenter.node.ToolTipField)
 		{
-			this.monitorField(pGroups[i]);
+			this.monitorField(node);
 		}
 	}
 };
@@ -60,7 +69,7 @@ br.presenter.util.ErrorMonitor.prototype.replaceErrorListeners = function(pGroup
  */
 br.presenter.util.ErrorMonitor.prototype.monitorField = function(oField)
 {
-	if (!oField instanceof br.presenter.node.ToolTipField)
+	if (!(oField instanceof br.presenter.node.ToolTipField))
 	{
 		throw new br.Errors.CustomError(br.Errors.INVALID_PARAMETERS, "The field to monitor has to be an instance of br.presenter.node.ToolTipField");
 	}
@@ -259,5 +268,5 @@ br.presenter.util.ErrorMonitor.prototype._addTooltipTo = function(oField)
  */
 br.presenter.util.ErrorMonitor.prototype._removeTooltipFrom = function(oField)
 {
-		oField.tooltipClassName.setValue("")
+	oField.tooltipClassName.setValue("")
 };

--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/tests/test-unit/js-test-driver/tests/br/presenter/util/ErrorMonitorTests.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/tests/test-unit/js-test-driver/tests/br/presenter/util/ErrorMonitorTests.js
@@ -1,0 +1,57 @@
+br.Core.thirdparty('jsmockito');
+
+(function() {
+
+	"use strict";
+
+	var errorMonitor;
+	var tooltipNode;
+
+	var testCaseName = "ErrorMonitorTests";
+	var testCase = {
+
+		setUp: function() {
+			tooltipNode = new br.presenter.node.ToolTipNode();
+			errorMonitor = new br.presenter.util.ErrorMonitor(tooltipNode);
+		},
+
+		tearDown: function() {},
+
+		"test addErrorListeners ignores fields that are not ToolTipFields": function() {
+			//given
+			var field = new br.presenter.node.Field();
+			field.hasError = spy(field.hasError);
+
+			//when
+			errorMonitor.addErrorListeners([field]);
+
+			//then
+			verify(field.hasError, times(0)).addChangeListener();
+		},
+
+		"test addErrorListeners monitors fields that are ToolTipFields": function() {
+			//given
+			var toolTipField = new br.presenter.node.ToolTipField();
+			toolTipField.hasError = spy(toolTipField.hasError);
+
+			//when
+			errorMonitor.addErrorListeners([toolTipField]);
+
+			//then
+			verify(toolTipField.hasError, times(1)).addChangeListener();
+		},
+
+		"test monitorField fails when field passed in is not a ToolTipField": function() {
+			//given
+			var field = new br.presenter.node.Field();
+
+			//when
+			assertFails("A ToolTipField must be passed in.", function() { errorMonitor.monitorField(field) });
+		}
+
+
+	};
+
+	TestCase(testCaseName, testCase);
+
+})();


### PR DESCRIPTION
Fixing tabbing issues in error monitor.
Fixing bug where error was never thrown in monitorField
Fixing bug where addErrorListeners should check against ToolTipNode as it also include tooltipClassName
Adding tests
