### PR TITLE
Add new date formats.

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/parser/DateParser.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/parser/DateParser.js
@@ -17,8 +17,11 @@
 br.presenter.parser.DateParser = function()
 {
 	this.m_pAmericanFormats = ["MM-DD-YYYY", "MM-DD-YY", "MMM-DD-YYYY", "MMM-DD-YY", "MM-DD"];
-	this.m_pEuropeanFormats = ["DD-MM-YYYY", "DD-MMM-YYYY", "DD-MM"];
-	this.m_pCommonFormats = ["DD-MMM-YYYY HH:mm:ss", "DD-MMM-YY HH:mm:ss", "DD-MMM-YYYY HH:mm", "YYYY-MM-DD", "YYYYMMDDHHmmss", "YYYYMMDDHHmm", "YYYYMMDD"];
+	this.m_pEuropeanFormats = ["DD-MM-YYYY", "DD-MMM-YYYY", "DD-MM", "DD-MM-YY", "DDMMYY", "DDMMYYYY"];
+	this.m_pCommonFormats = [
+		"DD-MMM-YYYY HH:mm:ss", "DD-MMM-YY HH:mm:ss", "DD-MMM-YYYY HH:mm", "YYYY-MM-DD", "YYYYMMDDHHmmss", 
+		"YYYYMMDDHHmm", "YYYYMMDD"
+	];
 	this.m_sSeparatorsDefault = "\\/.-";
 	this.m_oDateFormatter = new br.presenter.formatter.DateFormatter();
 };


### PR DESCRIPTION
This came from a JIRA for CT.

CT and BRJS both have the DateParser, just under different namespaces. But, we are currently not proxying our version to BRJS as there are some other issues we need to resolve first. That's why this PR, so that the fixes don't get lost once we do proxy trough ...
