### PR TITLE
Adding the a hasToolTip to allow css classes to be added within maps

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/ToolTipField.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/ToolTipField.js
@@ -1,15 +1,15 @@
 /**
  * Constructs a new instance of <code>ToolTipField</code>.
- * 
+ *
  * @class
  * A <code>PresentationNode</code> containing all of the attributes necessary to
- * model an input field on screen with a tool tip box that will be displayed when 
+ * model an input field on screen with a tool tip box that will be displayed when
  * a validation error has been produced.
- * 
+ *
  * <p>The element you are modeling with this field should have as css property the tooltipClassName
  * in order to control wich is the filed on error. This css class will be set by the {@link br.presenter.util.ErrorMonitor}.
  * Also, see {@link br.presenter.control.tooltip.TooltipControl} on how to model the tool tip box.</p>
- * 
+ *
  * @constructor
  * @param {Object} vValue (optional) The initial value of the field, either using a
  * primitive type or as a {@link br.presenter.property.EditableProperty}.
@@ -19,5 +19,13 @@ br.presenter.node.ToolTipField = function(vValue)
 {
 	br.presenter.node.Field.call(this, vValue);
 	this.tooltipClassName = new br.presenter.property.WritableProperty(false);
+
+	this.hasToolTip = new br.presenter.property.WritableProperty(false);
+
+	var tooltipClassNamePropertyListener = new br.presenter.property.PropertyListener();
+	tooltipClassNamePropertyListener.onPropertyChanged = function() {
+		this.hasToolTip.setValue(this.tooltipClassName.getValue() !== "")
+	}.bind(this);
+	this.tooltipClassName.addListener(tooltipClassNamePropertyListener, true);
 };
 br.Core.extend(br.presenter.node.ToolTipField, br.presenter.node.Field);

--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/tests/test-unit/js-test-driver/tests/br/presenter/node/ToolTipFieldTests.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/tests/test-unit/js-test-driver/tests/br/presenter/node/ToolTipFieldTests.js
@@ -1,0 +1,42 @@
+br.Core.thirdparty('jsmockito');
+
+(function() {
+
+	"use strict";
+
+	var toolTipField;
+
+	var testCaseName = "ToolTipFieldTests";
+	var testCase = {
+
+		setUp: function() {
+			toolTipField = new br.presenter.node.ToolTipField();
+		},
+
+		tearDown: function() {},
+
+		"test hasTooltip is true when a className is present": function() {
+
+			//when
+			toolTipField.tooltipClassName.setValue("a-tooltip");
+
+			//then
+			assertTrue("hasTooltip should be true", toolTipField.hasToolTip.getValue());
+		},
+
+		"test hasTooltip is false when className is empty": function() {
+
+			//when
+			toolTipField.tooltipClassName.setValue("a-tooltip");
+			toolTipField.tooltipClassName.setValue("");
+
+			//then
+			assertFalse("hasTooltip should be false", toolTipField.hasToolTip.getValue());
+		}
+
+
+	};
+
+	TestCase(testCaseName, testCase);
+
+})();


### PR DESCRIPTION
The current functionality expects the tooltipClass to be bound like this:

<div data-bind=”css: tooltipClassName”></div>
 

Where tooltipClassName is either “” or “has-error”.

Having a hasTooltip property allows us to have multiple css bindings on the same field (true for nearly every case):

<div data-bind=”css:{‘has-error’:value.hasTooltip, ‘another-class’:anotherClassApplied}”></div>


This can also be solved by doing 'another-class':tooltipClassName, but is not explicit. 
