### PR TITLE
reduce buffer memory usage in comment strippers

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
@@ -3,9 +3,9 @@ package org.bladerunnerjs.model;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.naming.InvalidNameException;
 
@@ -33,6 +33,7 @@ import org.bladerunnerjs.utility.UserCommandRunner;
 import org.bladerunnerjs.utility.VersionInfo;
 import org.bladerunnerjs.utility.filemodification.FileModificationInfo;
 import org.bladerunnerjs.utility.filemodification.FileModificationService;
+import org.bladerunnerjs.utility.reader.CharBufferPool;
 
 
 public class BRJS extends AbstractBRJSRootNode
@@ -73,6 +74,7 @@ public class BRJS extends AbstractBRJSRootNode
 	private final IO io = new IO();
 	private boolean closed = false;
 	private AppVersionGenerator appVersionGenerator;
+	private CharBufferPool pool = new CharBufferPool();
 	
 	BRJS(File brjsDir, PluginLocator pluginLocator, FileModificationService fileModificationService, 
 			LoggerFactory loggerFactory, AppVersionGenerator appVersionGenerator) throws InvalidSdkDirectoryException
@@ -99,6 +101,10 @@ public class BRJS extends AbstractBRJSRootNode
 		commandList = new CommandList(this, pluginLocator.getCommandPlugins());
 		
 		this.appVersionGenerator = appVersionGenerator;
+	}
+	
+	public CharBufferPool getCharBufferPool(){
+		return pool;
 	}
 	
 	@Override

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/TrieBasedDependenciesCalculator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/TrieBasedDependenciesCalculator.java
@@ -14,6 +14,7 @@ import org.bladerunnerjs.memoization.Getter;
 import org.bladerunnerjs.memoization.MemoizedValue;
 import org.bladerunnerjs.model.exception.ModelOperationException;
 import org.bladerunnerjs.utility.reader.AssetReaderFactory;
+import org.bladerunnerjs.utility.reader.CharBufferPool;
 import org.bladerunnerjs.utility.trie.AliasReference;
 import org.bladerunnerjs.utility.trie.AssetReference;
 import org.bladerunnerjs.utility.trie.LinkedAssetReference;
@@ -72,8 +73,9 @@ public class TrieBasedDependenciesCalculator
 			@Override
 			public Object get() throws ModelOperationException {
 				ComputedValue computedValue = new ComputedValue();
+				CharBufferPool pool = assetLocation.root().getCharBufferPool();
 				
-				try(Reader reader = readerFactory.createReader()) {
+				try(Reader reader = readerFactory.createReader(pool)) {
 					Trie<AssetReference> trie = trieFactory.createTrie();
 					
 					for(Object match : trie.getMatches(reader)) {

--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/commonjs/CommonJsSourceModule.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/commonjs/CommonJsSourceModule.java
@@ -160,7 +160,8 @@ public class CommonJsSourceModule implements AugmentedContentSourceModule {
 			public Object get() throws ModelOperationException {
 				ComputedValue computedValue = new ComputedValue();
 				
-				try(Reader fileReader = new JsCommentStrippingReader(getReader(), false)) {
+				
+				try(Reader fileReader = new JsCommentStrippingReader(getReader(), false, assetLocation.root().getCharBufferPool())) {
 					StringWriter stringWriter = new StringWriter();
 					IOUtils.copy(fileReader, stringWriter);
 					

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/AssetReaderFactory.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/AssetReaderFactory.java
@@ -4,5 +4,5 @@ import java.io.IOException;
 import java.io.Reader;
 
 public interface AssetReaderFactory {
-	Reader createReader() throws IOException;
+	Reader createReader(CharBufferPool pool) throws IOException;
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/CharBufferPool.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/CharBufferPool.java
@@ -4,9 +4,9 @@ import java.util.Stack;
 
 public class CharBufferPool {
 	
-	private static Stack<char[]> pool = new Stack<char[]>();
+	private Stack<char[]> pool = new Stack<char[]>();
 	
-	public static synchronized char[] getBuffer(){
+	public  synchronized char[] getBuffer(){
 		char[] result = null;
 		if(pool.isEmpty()){
 			result = new char[4096];
@@ -16,7 +16,7 @@ public class CharBufferPool {
 		return result;
 	}
 	
-	public static synchronized void returnBuffer(char[] buffer){
+	public synchronized void returnBuffer(char[] buffer){
 		pool.push(buffer);
 	}
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsCodeBlockStrippingDependenciesReader.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsCodeBlockStrippingDependenciesReader.java
@@ -33,11 +33,13 @@ public class JsCodeBlockStrippingDependenciesReader extends Reader
 	private int nextCharPos = 0;
 	private int lastCharPos = 0;
 	private int depthCount = 0;
+	private CharBufferPool pool;
 	
 	
-	public JsCodeBlockStrippingDependenciesReader(Reader sourceReader) {
+	public JsCodeBlockStrippingDependenciesReader(Reader sourceReader, CharBufferPool pool) {
 		super();
 		this.sourceReader = sourceReader;
+		this.pool = pool;
 	}
 	
 	@Override
@@ -49,7 +51,7 @@ public class JsCodeBlockStrippingDependenciesReader extends Reader
 		int currentOffset = offset;
 		int maxOffset = offset + maxCharacters;
 		char nextChar;
-		char[] sourceBuffer = CharBufferPool.getBuffer();
+		char[] sourceBuffer = pool.getBuffer();
 		
 		while(currentOffset < maxOffset) {
 			if (nextCharPos == lastCharPos) {
@@ -84,7 +86,7 @@ public class JsCodeBlockStrippingDependenciesReader extends Reader
 			}
 		}
 		
-		CharBufferPool.returnBuffer(sourceBuffer);
+		pool.returnBuffer(sourceBuffer);
 		int charsProvided = (currentOffset - offset);
 		return (charsProvided == 0) ? -1 : charsProvided;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsCommentStrippingReader.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsCommentStrippingReader.java
@@ -28,12 +28,14 @@ public class JsCommentStrippingReader extends Reader
 	private int nextCharPos = 0;
 	private int lastCharPos = 0;
 	private CommentStripperState state;
+	private CharBufferPool pool;
 	
-	public JsCommentStrippingReader(Reader sourceReader, boolean preserveJsdoc)
+	public JsCommentStrippingReader(Reader sourceReader, boolean preserveJsdoc, CharBufferPool pool)
 	{
 		super();
 		this.sourceReader = sourceReader;
 		this.preserveJsdoc = preserveJsdoc;
+		this.pool = pool;
 		state = CommentStripperState.WITHIN_SOURCE;
 	}
 	
@@ -46,7 +48,7 @@ public class JsCommentStrippingReader extends Reader
 		int currentOffset = offset;
 		int maxOffset = offset + maxCharacters - (MAX_SINGLE_WRITE - 1);
 		char previousChar, nextChar = '\0';
-		char[] sourceBuffer = CharBufferPool.getBuffer();
+		char[] sourceBuffer = pool.getBuffer();
 		
 		while(currentOffset < maxOffset) {
 			if(nextCharPos == lastCharPos) {
@@ -178,7 +180,7 @@ public class JsCommentStrippingReader extends Reader
 			}
 		}
 		
-		CharBufferPool.returnBuffer(sourceBuffer);
+		pool.returnBuffer(sourceBuffer);
 		int charsProvided = (currentOffset - offset);
 		return (charsProvided == 0) ? -1 : charsProvided;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsStringStrippingReader.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/JsStringStrippingReader.java
@@ -20,11 +20,13 @@ public class JsStringStrippingReader extends Reader
 	private int nextCharPos = 0;
 	private int lastCharPos = 0;
 	private StringStripperState state = StringStripperState.WITHIN_SOURCE;
+	private CharBufferPool pool;
 	
-	public JsStringStrippingReader(Reader sourceReader)
+	public JsStringStrippingReader(Reader sourceReader, CharBufferPool pool)
 	{
 		super();
 		this.sourceReader = sourceReader;
+		this.pool = pool;
 	}
 	
 	@Override
@@ -36,7 +38,7 @@ public class JsStringStrippingReader extends Reader
 		int currentOffset = offset;
 		int maxOffset = offset + maxCharacters;
 		char nextChar;
-		char[] sourceBuffer = CharBufferPool.getBuffer();
+		char[] sourceBuffer = pool.getBuffer();
 		
 		while(currentOffset < maxOffset) {
 			if(nextCharPos == lastCharPos) {
@@ -82,7 +84,7 @@ public class JsStringStrippingReader extends Reader
 			}
 		}
 		
-		CharBufferPool.returnBuffer(sourceBuffer);
+		pool.returnBuffer(sourceBuffer);
 		int charsProvided = (currentOffset - offset);
 		return (charsProvided == 0) ? -1 : charsProvided;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/XmlCommentStrippingDependenciesReader.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/XmlCommentStrippingDependenciesReader.java
@@ -34,11 +34,13 @@ public class XmlCommentStrippingDependenciesReader extends Reader
 	private int nextCharPos = 0;
 	private int lastCharPos = 0;
 	private CommentStripperState state;
+	private CharBufferPool pool;
 	
-	public XmlCommentStrippingDependenciesReader(Reader sourceReader)
+	public XmlCommentStrippingDependenciesReader(Reader sourceReader, CharBufferPool pool)
 	{
 		super();
 		this.sourceReader = sourceReader;
+		this.pool = pool;
 		state = CommentStripperState.WITHIN_SOURCE;
 	}
 	
@@ -51,7 +53,7 @@ public class XmlCommentStrippingDependenciesReader extends Reader
 		int currentOffset = offset;
 		int maxOffset = offset + maxCharacters;
 		char nextChar;
-		char[] sourceBuffer = CharBufferPool.getBuffer();
+		char[] sourceBuffer = pool.getBuffer();
 		
 		while(currentOffset < maxOffset) {
 			if(nextCharPos == lastCharPos) {
@@ -82,7 +84,7 @@ public class XmlCommentStrippingDependenciesReader extends Reader
 			}
 		}
 		
-		CharBufferPool.returnBuffer(sourceBuffer);
+		pool.returnBuffer(sourceBuffer);
 		int charsProvided = (currentOffset - offset);
 		return (charsProvided == 0) ? -1 : charsProvided;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsAndXmlCommentStrippingReaderFactory.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsAndXmlCommentStrippingReaderFactory.java
@@ -5,6 +5,7 @@ import java.io.Reader;
 
 import org.bladerunnerjs.model.Asset;
 import org.bladerunnerjs.utility.reader.AssetReaderFactory;
+import org.bladerunnerjs.utility.reader.CharBufferPool;
 import org.bladerunnerjs.utility.reader.JsCommentStrippingReader;
 import org.bladerunnerjs.utility.reader.XmlCommentStrippingDependenciesReader;
 
@@ -18,9 +19,10 @@ public class JsAndXmlCommentStrippingReaderFactory implements AssetReaderFactory
 	}
 	
 	@Override
-	public Reader createReader() throws IOException {
-		Reader jsCommentStrippingReader = new JsCommentStrippingReader(asset.getReader(), false);
-		Reader jsCommentStrippingAndXmlStrippingReader = new XmlCommentStrippingDependenciesReader(jsCommentStrippingReader);
+	public Reader createReader(CharBufferPool pool) throws IOException {
+		
+		Reader jsCommentStrippingReader = new JsCommentStrippingReader(asset.getReader(), false, pool);
+		Reader jsCommentStrippingAndXmlStrippingReader = new XmlCommentStrippingDependenciesReader(jsCommentStrippingReader, pool);
 		
 		return jsCommentStrippingAndXmlStrippingReader;
 		

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsCommentAndCodeBlockStrippingReaderFactory.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsCommentAndCodeBlockStrippingReaderFactory.java
@@ -5,6 +5,7 @@ import java.io.Reader;
 
 import org.bladerunnerjs.model.AugmentedContentSourceModule;
 import org.bladerunnerjs.utility.reader.AssetReaderFactory;
+import org.bladerunnerjs.utility.reader.CharBufferPool;
 import org.bladerunnerjs.utility.reader.JsCodeBlockStrippingDependenciesReader;
 import org.bladerunnerjs.utility.reader.JsCommentStrippingReader;
 import org.bladerunnerjs.utility.reader.JsStringStrippingReader;
@@ -19,10 +20,10 @@ public class JsCommentAndCodeBlockStrippingReaderFactory implements AssetReaderF
 	}
 	
 	@Override
-	public Reader createReader() throws IOException {
-		Reader commentStrippingReader = new JsCommentStrippingReader(sourceModule.getUnalteredContentReader(), false);
-		Reader commentStrippingAndStringStrippingReader = new JsStringStrippingReader(commentStrippingReader);
-		Reader commentStrippingAndStringStrippingAndCodeBlockStrippingReader = new JsCodeBlockStrippingDependenciesReader(commentStrippingAndStringStrippingReader);
+	public Reader createReader(CharBufferPool pool) throws IOException {
+		Reader commentStrippingReader = new JsCommentStrippingReader(sourceModule.getUnalteredContentReader(), false, pool);
+		Reader commentStrippingAndStringStrippingReader = new JsStringStrippingReader(commentStrippingReader, pool);
+		Reader commentStrippingAndStringStrippingAndCodeBlockStrippingReader = new JsCodeBlockStrippingDependenciesReader(commentStrippingAndStringStrippingReader, pool);
 		
 		return commentStrippingAndStringStrippingAndCodeBlockStrippingReader;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsCommentStrippingReaderFactory.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/reader/factory/JsCommentStrippingReaderFactory.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import org.bladerunnerjs.model.Asset;
 import org.bladerunnerjs.model.AugmentedContentSourceModule;
 import org.bladerunnerjs.utility.reader.AssetReaderFactory;
+import org.bladerunnerjs.utility.reader.CharBufferPool;
 import org.bladerunnerjs.utility.reader.JsCommentStrippingReader;
 
 public class JsCommentStrippingReaderFactory implements AssetReaderFactory {
@@ -18,7 +19,7 @@ public class JsCommentStrippingReaderFactory implements AssetReaderFactory {
 	}
 	
 	@Override
-	public Reader createReader() throws IOException {
+	public Reader createReader(CharBufferPool pool) throws IOException {
 		Reader reader = null;
 		if(asset instanceof AugmentedContentSourceModule){
 			AugmentedContentSourceModule source = (AugmentedContentSourceModule)asset;
@@ -26,6 +27,6 @@ public class JsCommentStrippingReaderFactory implements AssetReaderFactory {
 		}else{
 			reader = asset.getReader();
 		}
-		return new JsCommentStrippingReader(reader, false);
+		return new JsCommentStrippingReader(reader, false, pool);
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsCodeBlockStrippingDependenciesReaderTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsCodeBlockStrippingDependenciesReaderTest.java
@@ -373,7 +373,8 @@ public class JsCodeBlockStrippingDependenciesReaderTest
 	
 	private void stripCodeBlocksAndAssertEquals(String input, String expectedOutput) throws IOException
 	{
-		try(Reader reader = new JsCodeBlockStrippingDependenciesReader(new StringReader(input));
+		CharBufferPool pool = new CharBufferPool();
+		try(Reader reader = new JsCodeBlockStrippingDependenciesReader(new StringReader(input), pool);
 			    StringWriter stringWriter = new StringWriter())
 			{
 				IOUtils.copy(reader, stringWriter);

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsCommentStrippingReaderTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsCommentStrippingReaderTest.java
@@ -312,7 +312,8 @@ public class JsCommentStrippingReaderTest
 	
 	private String stripComments(String input, boolean preserveJsdoc) throws IOException
 	{
-		try(Reader reader = new JsCommentStrippingReader(new StringReader(input), preserveJsdoc);
+		
+		try(Reader reader = new JsCommentStrippingReader(new StringReader(input), preserveJsdoc, new CharBufferPool());
 		    StringWriter stringWriter = new StringWriter())
 		{
 			IOUtils.copy(reader, stringWriter);

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsStringStrippingReaderTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/JsStringStrippingReaderTest.java
@@ -176,7 +176,7 @@ public class JsStringStrippingReaderTest
 	
 	private void stripStringsAndAssertEquals(String input, String expectedOutput) throws IOException
 	{
-		try(Reader reader = new JsStringStrippingReader(new StringReader(input));
+		try(Reader reader = new JsStringStrippingReader(new StringReader(input), new CharBufferPool());
 			    StringWriter stringWriter = new StringWriter())
 			{
 				IOUtils.copy(reader, stringWriter);

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/XmlCommentStrippingDependenciesReaderTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/reader/XmlCommentStrippingDependenciesReaderTest.java
@@ -190,7 +190,7 @@ public class XmlCommentStrippingDependenciesReaderTest
 	
 	private String stripComments(String input) throws IOException
 	{
-		try(Reader reader = new XmlCommentStrippingDependenciesReader(new StringReader(input)); StringWriter stringWriter = new StringWriter())
+		try(Reader reader = new XmlCommentStrippingDependenciesReader(new StringReader(input), new CharBufferPool()); StringWriter stringWriter = new StringWriter())
 		{
 			IOUtils.copy(reader, stringWriter);
 			return stringWriter.toString();


### PR DESCRIPTION
In CT 3000 (ish) comment stripper instances are created, each of which includes a 4K char buffer.
Using a buffer pool save 10-15MB of memory churn on a decent sized app
