### PR TITLE
Changed logging level for 'server already running' message. Resolves #353

### DIFF
--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/TestRunner.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/TestRunner.java
@@ -291,7 +291,7 @@ public class TestRunner {
 		boolean serverStarted = false;
 		
 		if(isServerRunning()) {
-			logger.info("Server already running, not bothering to start a new instance...");
+			logger.console("Server already running, not bothering to start a new instance...");
 		}
 		else {
 			startServerProcess();


### PR DESCRIPTION
As above. Now the message should appear at every logging level (also with the default one).
@thecapdan - fixes the issue mentioned in this [comment](https://github.com/BladeRunnerJS/brjs/issues/353#issuecomment-51448127)
