### PR TITLE
Add a tearDown method, so fixture gets cleared down properly

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/testing/PresentationModelFixture.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/testing/PresentationModelFixture.js
@@ -36,6 +36,11 @@ br.presenter.testing.PresentationModelFixture.prototype.setComponent = function(
 // *							  Fixture interface
 // ************************************************************************************
 
+br.presenter.testing.PresentationModelFixture.prototype.tearDown = function()
+{
+	delete this.m_oPresentationModel;
+};
+
 br.presenter.testing.PresentationModelFixture.prototype.canHandleExactMatch = function()
 {
 	return false;


### PR DESCRIPTION
This was raised as an issue from the motif.
