### PR TITLE
Added clean-up code to file observer tests, so that all watch handles

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTestDirObserverBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTestDirObserverBuilder.java
@@ -3,17 +3,13 @@ package org.bladerunnerjs.testing.specutility.engine;
 import java.io.File;
 
 import org.bladerunnerjs.model.BRJS;
-import org.bladerunnerjs.testing.utility.StubLoggerFactory;
 import org.bladerunnerjs.testing.utility.SpecTestDirObserver;
-import org.bladerunnerjs.utility.filemodification.FileModificationService;
-import org.bladerunnerjs.utility.filemodification.Java7FileModificationService;
 
 
 public class SpecTestDirObserverBuilder
 {
 	private SpecTestDirObserver observer;
 	private BuilderChainer builderChainer;
-	
 	
 	public SpecTestDirObserverBuilder(SpecTest specTest, SpecTestDirObserver observer)
 	{
@@ -23,10 +19,8 @@ public class SpecTestDirObserverBuilder
 
 	public BuilderChainer isObservingDir(File dir, BRJS brjs)
 	{
-		FileModificationService fileModificationService = new Java7FileModificationService(new StubLoggerFactory());
-		fileModificationService.initialise(brjs, dir);
-		
-		observer.setDirObserver( fileModificationService.getModificationInfo(dir) );
+		observer.getFileModificationService().initialise(brjs, dir);
+		observer.setDirObserver( observer.getFileModificationService().getModificationInfo(dir) );
 		
 		return builderChainer;
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/SpecTestDirObserver.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/utility/SpecTestDirObserver.java
@@ -1,12 +1,15 @@
 package org.bladerunnerjs.testing.utility;
 
+import org.bladerunnerjs.utility.filemodification.FileModificationService;
 import org.bladerunnerjs.utility.filemodification.FileModifiedChecker;
 import org.bladerunnerjs.utility.filemodification.InfoFileModifiedChecker;
 import org.bladerunnerjs.utility.filemodification.FileModificationInfo;
+import org.bladerunnerjs.utility.filemodification.Java7FileModificationService;
 
 
 public class SpecTestDirObserver
 {
+	private final Java7FileModificationService fileModificationService = new Java7FileModificationService(new StubLoggerFactory());;
 	private FileModifiedChecker fileModificationChecker;
 	
 	public FileModifiedChecker getDirObserver()
@@ -17,5 +20,9 @@ public class SpecTestDirObserver
 	public void setDirObserver(FileModificationInfo fileModificationInfo)
 	{
 		this.fileModificationChecker = new InfoFileModifiedChecker(fileModificationInfo);
+	}
+
+	public FileModificationService getFileModificationService() {
+		return fileModificationService;
 	}
 }


### PR DESCRIPTION
are released before the next test is run, and modified
Java7FileModificationService.close() so it becomes a synchronous
blocking method we can rely on to have worked by the time it returns.
