### PR TITLE
giving splice method necessary arguments so it works in IE

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/view/knockout/KnockoutProperty.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/view/knockout/KnockoutProperty.js
@@ -44,8 +44,7 @@ br.presenter.view.knockout.KnockoutProperty.createArrayMethod = function(sMethod
 	return function()
 	{
 		var pUnderlyingArray = this.getValue();
-		var nUnderlyingArrayLength = pUnderlyingArray.length;
-		var pNewArray = pUnderlyingArray.splice(0, nUnderlyingArrayLength);
+		var pNewArray = pUnderlyingArray.splice(0, pUnderlyingArray.length);
 		Array.prototype[sMethod].apply(pNewArray, arguments);
 		this.setValue(pNewArray);
 	};


### PR DESCRIPTION
The splice() method was being invoked without a howMany parameter. That will only work in Chrome and Firefox. 
