### PR TITLE
Modified '.gitignore' to keep Eclipse Kepler happy, which stopped being

### DIFF
--- a/brjs-sdk/.gitignore
+++ b/brjs-sdk/.gitignore
@@ -29,3 +29,4 @@ workspace/sdk/phantomjs
 #   2. Egit currently won't consider recursive matches defined before a blanket block pattern, followed by negated block patterns (!), so is ignoring matches in the main brjs .gitignore
 brjs-*.jar
 *.bundle
+bundle.js


### PR DESCRIPTION
happy a few months ago after a change somebody else made to '.gitignore'
that works for the real version of Git.

<!---
@huboard:{"order":607.0,"milestone_order":963,"custom_state":""}
-->
