### PR TITLE
Fix Xml bundler not working in prod

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XMLContentPlugin.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XMLContentPlugin.java
@@ -108,9 +108,7 @@ public class XMLContentPlugin extends AbstractContentPlugin
 		}
 	}
 	
-	private List<String> getValidContentPaths(BundleSet bundleSet) throws ContentProcessingException {
-		XmlBundlerConfig config = new XmlBundlerConfig(brjs);
-		
-		return (!config.isbundleConfigAvailable() || bundleSet.getResourceFiles(xmlAssetPlugin).isEmpty()) ? Collections.emptyList() : requestPaths;
+	private List<String> getValidContentPaths(BundleSet bundleSet) throws ContentProcessingException {		
+		return bundleSet.getResourceFiles(xmlAssetPlugin).isEmpty() ? Collections.emptyList() : requestPaths;
 	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/xml/XMLContentPluginTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/xml/XMLContentPluginTest.java
@@ -58,12 +58,6 @@ public class XMLContentPluginTest extends SpecTest{
 	}
 	
 	@Test
-	public void ifThereAreXmlFilesButNoBundleConfigThenNoRequestsWillBeGenerated() throws Exception {
-		given(aspect).containsResourceFile("config.xml");
-		then(aspect).prodAndDevRequestsForContentPluginsAreEmpty("xml");
-	}
-	
-	@Test
 	public void ifThereIsABundleConfigButNoXmlFilesThenNoRequestsWillBeGenerated() throws Exception {
 		given(brjsConf).containsFile("bundleConfig.xml");
 		then(aspect).prodAndDevRequestsForContentPluginsAreEmpty("xml");
@@ -73,6 +67,12 @@ public class XMLContentPluginTest extends SpecTest{
 	public void ifThereIsBothABundleConfigAndXmlFilesThenRequestsWillBeGenerated() throws Exception {
 		given(brjsConf).containsFile("bundleConfig.xml")
 			.and(aspect).containsResourceFile("config.xml");
+		then(aspect).prodAndDevRequestsForContentPluginsAre("xml", "xml/bundle.xml");
+	}
+	
+	@Test
+	public void ifThereAreXmlFilesButNoBundleConfigThenRequestsWillStillBeGenerated() throws Exception {
+		given(aspect).containsResourceFile("config.xml");
 		then(aspect).prodAndDevRequestsForContentPluginsAre("xml", "xml/bundle.xml");
 	}
 	


### PR DESCRIPTION
Fixes #954
XML bundler already concatenated XML files if no bundler config was present. It now returns the correct requests if the bundler config file isn't present.
