### PR TITLE
Stopped verifiying the alias blob at load time since this caused AliasRe...

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/resources/aliasDefinitions.xml
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/resources/aliasDefinitions.xml
@@ -1,7 +1,7 @@
 <aliasDefinitions xmlns="http://schema.caplin.com/CaplinTrader/aliasDefinitions">
 	<alias name="some.alias1" defaultClass="br.a.AliasClass1" interface="br.Alias1Interface"/>
 	<alias name="some.alias2" defaultClass="br.b.AliasClass2"/>
-	<alias name="some.alias3" interface="br.Alias1Interface"/>
+	<alias name="some.alias3" interface="br.Alias3Interface"/>
 	
 	<alias name="my.service" defaultClass="br.UnknownClass"/>
 	<alias name="my.404-service" defaultClass="br.UnknownClass"/>

--- a/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/src-test/br/Alias3Interface.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/src-test/br/Alias3Interface.js
@@ -1,0 +1,7 @@
+function Alias3Interface() {
+};
+
+Alias3Interface.prototype.interfaceFunction3 = function() {
+};
+
+module.exports = Alias3Interface;

--- a/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/tests/AliasRegistryTest.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/tests/AliasRegistryTest.js
@@ -13,7 +13,7 @@
 	var Alias2Interface = require('br/Alias2Interface');
 	var Alias1AlternateInterface = require('br/Alias1AlternateInterface');
 
-	var AliasRegistry = require('br/AliasRegistry').constructor;
+	var AliasRegistry = require('br/AliasRegistryClass');
 	var AliasRegistryTest = TestCase("AliasRegistryTest").prototype;
 
 	var aliasRegistry = null;
@@ -101,15 +101,17 @@
 
 	AliasRegistryTest["test Fails fast if alias is not an implementer of the alias interface"] = function()
 	{
+		var aliasRegistry = new AliasRegistry({
+			"some.alias1": {
+				"class":"br/a/AliasClass1",
+				"className":"br.a.AliasClass1",
+				"interface":"br/Alias2Interface",
+				"interfaceName":"br.Alias2Interface"
+			}});
+		
 		assertException("Should throw an error if the alias is not implementor of the alias interface",
 			function() {
-				new AliasRegistry({
-					"some.alias1": {
-						"class":"br/a/AliasClass1",
-						"className":"br.a.AliasClass1",
-						"interface":"br/Alias2Interface",
-						"interfaceName":"br.Alias2Interface"
-					}});
+				aliasRegistry.getClass('some.alias1');
 			},
 			Errors.ILLEGAL_STATE
 		);

--- a/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/tests/ServiceRegistryTest.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br/test-unit/tests/ServiceRegistryTest.js
@@ -67,10 +67,9 @@
 	};
 
 	ServiceRegistryTest.test_getService_WorksWithServicesRegisteredWithAliases = function() {
-		var AliasRegistry = require('br/AliasRegistry');
-		var MyService = function() {};
-
-		AliasRegistry._aliasData = {'my.service': {'class': MyService, 'className': 'my.Service'}};
+		window.MyService = function() {};
+		var aliasRegistry = require('br/AliasRegistry');
+		aliasRegistry._aliasData = {'my.service': {'class': 'MyService', 'className': 'my.Service'}};
 
 		assertTrue(ServiceRegistry.getService('my.service') instanceof MyService);
 	};


### PR DESCRIPTION
...gistry to statically depend on all classes and interfaces defined by alias, and instead now perform validation lazilly as aliases are required.
