### PR TITLE
Fix a bug in `ToolTipField`

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/ToolTipField.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/ToolTipField.js
@@ -24,7 +24,7 @@
 br.presenter.node.ToolTipField = function(vValue)
 {
 	br.presenter.node.Field.call(this, vValue);
-	this.tooltipClassName = new br.presenter.property.WritableProperty(false);
+	this.tooltipClassName = new br.presenter.property.WritableProperty('');
 
 	this.hasToolTip = new br.presenter.property.WritableProperty(false);
 


### PR DESCRIPTION
Because the `tooltipClassName` had the initial value of `false` and the `tooltipClassNamePropertyListener` fired mediately the check it does would flip the `hasToolTip` to `true` even though there was no error ...

<!---
@huboard:{"order":0.1474609375,"milestone_order":1015,"custom_state":""}
-->
