### PR TITLE
Add a `selectedOptionLabel` property to `SelectionField`.

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
@@ -119,6 +119,13 @@ br.presenter.node.SelectionField = function(vOptions, vValue)
 	
 	// validate the initial values
 	this.value.forceValidation();
+
+	/**
+	 * The current text value of the selected option's label.
+	 * @type {br.presenter.property.Property}
+	 */
+	this.selectedOptionLabel = new br.presenter.property.Property();
+	this.value.addChangeListener(this, '_updateSelectedOptionLabel', true);
 };
 br.Core.extend(br.presenter.node.SelectionField, br.presenter.node.PresentationNode);
 
@@ -178,5 +185,16 @@ br.presenter.node.SelectionField.prototype._automaticallyUpdateValueOnOptionsCha
 				oValueProperty.setUserEnteredValue(vNewValue);
 			}
 		}
+	}
+};
+
+/** @private */
+br.presenter.node.SelectionField.prototype._updateSelectedOptionLabel = function() {
+	var selectedOption = this.options.getOptionByValue(this.value.getValue());
+
+	if (selectedOption) {
+		this.selectedOptionLabel._$setInternalValue(selectedOption.label.getValue());
+	} else {
+		this.selectedOptionLabel._$setInternalValue("");
 	}
 };

--- a/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/SelectionFieldTest.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/SelectionFieldTest.js
@@ -264,3 +264,17 @@ SelectionFieldTest.prototype.test_canSetControlNameIndependentlyOfOtherPropertie
 	assertEquals("1b", "label", oSelectionField.label.getValue());
 	assertEquals("1c", "controlName", oSelectionField.controlName.getValue());
 };
+
+SelectionFieldTest.prototype.test_selectedOptionLabelIsInitiallySetToTheCorrectValue = function() {
+	var selectionField = new br.presenter.node.SelectionField(['foo', 'bar'], 'bar');
+
+	assertEquals('selectedOptionLabel is initialised correctly', 'bar', selectionField.selectedOptionLabel.getValue());
+};
+
+SelectionFieldTest.prototype.test_selectedOptionLabelIsUpdatedWhenSelectedValueChanges = function() {
+	var selectionField = new br.presenter.node.SelectionField(['foo', 'bar'], 'bar');
+
+	selectionField.value.setUserEnteredValue('foo');
+
+	assertEquals('selectedOptionLabel is updated', 'foo', selectionField.selectedOptionLabel.getValue());
+};


### PR DESCRIPTION
It contains the text value of the currently selected option's label.

<!---
@huboard:{"order":7.200241088867188e-05,"milestone_order":1048,"custom_state":""}
-->
