### PR TITLE
Add `setNodeText` function that sets the text contents of a element in a...

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-util/src/br/util/ElementUtility.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-util/src/br/util/ElementUtility.js
@@ -260,6 +260,21 @@ ElementUtility.setInnerHtml = function(element, htmlToSet) {
 };
 
 /**
+ * Sets the text contents of the specified element in an efficient way. This function should only be used for setting
+ *  plain text contents.
+ *
+ * @param {Element} element The element on which to set the new text content.
+ * @param {String} textToSet Text content to set on the element.
+ */
+ElementUtility.setNodeText = function(element, textToSet) {
+	if (!element.firstChild) {
+		element.appendChild(document.createTextNode(textToSet));
+	} else {
+		element.firstChild.nodeValue = textToSet;
+	}
+};
+
+/**
  * Removes the specified child from its parent.
  *
  * @param {Element} childElement The child to remove.

--- a/brjs-sdk/workspace/sdk/libs/javascript/br-util/test-unit/tests/br/util/ElementUtilityTest.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-util/test-unit/tests/br/util/ElementUtilityTest.js
@@ -1,0 +1,23 @@
+require('jsunitextensions');
+require('mock4js');
+
+var ElementUtility = require('br/util/ElementUtility');
+
+ElementUtilityTest = TestCase('ElementUtilityTest');
+
+ElementUtilityTest.prototype.test_setNodeText_SetsTheTextContentsOnAEmptyElement = function() {
+	var element = document.createElement('DIV');
+
+	ElementUtility.setNodeText(element, 'foo');
+
+	assertEquals(element.innerHTML, 'foo');
+};
+
+ElementUtilityTest.prototype.test_setNodeText_SetsTheTextContentsOnANonEmptyElement = function() {
+	var element = document.createElement('DIV');
+	element.innerHTML = 'bar';
+
+	ElementUtility.setNodeText(element, 'foo');
+
+	assertEquals(element.innerHTML, 'foo');
+};


### PR DESCRIPTION
Adds a function that sets the text contents on a element in a performant way.

Noticed `ElementUtility` has no tests, so I created a `ElementUtilityTest` file, but it only has tests for this new function.

<!---
@huboard:{"order":0.013824462890625,"milestone_order":1056,"custom_state":""}
-->
