### PR TITLE
File change watcher refinements

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/memoization/FileModificationWatcherThread.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/memoization/FileModificationWatcherThread.java
@@ -106,7 +106,7 @@ public class FileModificationWatcherThread extends Thread
             
             boolean isWatchKeyReset = watchKey.reset();
             if( !isWatchKeyReset ) {
-            	if (kind == ENTRY_DELETE && childFile.isDirectory()) {
+            	if (!childFile.exists()) {
             		watchKey.cancel();
             		watchKeys.remove(watchPath);            		
             	} else {


### PR DESCRIPTION
- increment all file version on an `OVERFLOW` event since these are only generated if there were too many file change events
- make sure watch keys that are no longer valid (i.e. the directory no longer exists or it couldnt be reset) are cleaned up
- logs a warning if a watch key could not be reset but the file still exists
