### PR TITLE
point fix for integration tests not being found

### DIFF
--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/IntegrationTestFinder.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/IntegrationTestFinder.java
@@ -42,6 +42,7 @@ public class IntegrationTestFinder
 		return testDirs;
 	}
 	
+	// This is all a huge hack - we need to move the test commands across to use the model so we dont have to guess at whether things are valid test integration dirs
 	private boolean isValidTestDir(BRJS brjs, MemoizedFile dir, boolean ignoreWorkbenches)
 	{		
 		boolean validTestDir = dir.isDirectory() 
@@ -50,7 +51,8 @@ public class IntegrationTestFinder
 		
 		File containingDir = dir.getParentFile().getParentFile();
 		File ancestorContainingDir = containingDir.getParentFile();
-		if (validTestDir && !(containingDir.getName().endsWith("-aspect") || ancestorContainingDir.getName().endsWith("-aspect") || containingDir.getName().equals("workbench")))
+		if (validTestDir && !(containingDir.getName().endsWith("-aspect") || ancestorContainingDir.getName().endsWith("-aspect") || 
+				containingDir.getName().equals("workbench") || ancestorContainingDir.getName().equals("workbench")))
 		{
 			validTestDir = false;
 			logger.info("Found integration test directory in "+dir.getPath()+"\n"+


### PR DESCRIPTION
point fix for integration tests not being found - this needs fixing properly by moving the test commands to the model.  because of changes to the model allowing default aspect and optional directory structures the test command logic for finding test dirs is now broken.
