### PR TITLE
Removed a dubious line of code (when an error occurred while importing a ...

### DIFF
--- a/brjs-sdk/workspace/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/model/dialog/importDialog/ImportMotifDialog.js
+++ b/brjs-sdk/workspace/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/model/dialog/importDialog/ImportMotifDialog.js
@@ -101,5 +101,4 @@ brjs.dashboard.app.model.dialog.importDialog.ImportMotifDialog.prototype._onSucc
 brjs.dashboard.app.model.dialog.importDialog.ImportMotifDialog.prototype._onFailure = function(sFailureMessage)
 {
 	this.m_oPresentationModel.dialog.displayNotification(sFailureMessage);
-	this.m_oPresentationModel.dialog.visible.setValue(false);
 };


### PR DESCRIPTION
...motif) that immediately hid the error notification dialog we'd just gone to the trouble of displaying.
