### PR TITLE
Use the same non-standard locale code format that we currently use on th...

### DIFF
--- a/brjs-sdk/workspace/sdk/libs/javascript/br-locale-utility/LocaleUtility.js
+++ b/brjs-sdk/workspace/sdk/libs/javascript/br-locale-utility/LocaleUtility.js
@@ -30,7 +30,6 @@ LocaleUtility.getBrowserAcceptedLocales = function() {
 	}
 
 	// convert locale codes to use underscores like we do on the server
-debugger;
 	for(var i = 0, l = userAcceptedLocales.length; i < l; ++i) {
 		var userAcceptedLocale = userAcceptedLocales[i];
 		userAcceptedLocales[i] = userAcceptedLocale.replace('-', '_');


### PR DESCRIPTION
...e server (underscores instead of hyphens).
