### PR TITLE
Updated 'resourceReaders' to use a 'LinkedHashMap' to preserve order.

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XmlBundleWriter.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XmlBundleWriter.java
@@ -6,6 +6,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +113,7 @@ public class XmlBundleWriter
 	/* returns a map of xml root elements to a list of xml sibling readers */
 	private Map<String, List<XmlSiblingReader>> getResourceReaders(List<Asset> xmlAssets) throws  ContentProcessingException
 	{
-		Map<String, List<XmlSiblingReader>> resourceReaders = new HashMap<String, List<XmlSiblingReader>>();
+		Map<String, List<XmlSiblingReader>> resourceReaders = new LinkedHashMap<String, List<XmlSiblingReader>>();
 		System.setProperty("javax.xml.stream.XMLInputFactory", "com.sun.xml.stream.ZephyrParserFactory");
 		XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 		

--- a/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/xml/XMLContentPluginTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/spec/plugin/bundler/xml/XMLContentPluginTest.java
@@ -260,8 +260,8 @@ public class XMLContentPluginTest extends SpecTest{
 			.and(aspect).containsResourceFileWithContents("config2.xml", rootElem2(templateElem(mergeElem("id2"))));
 		when(aspect).requestReceivedInDev("xml/bundle.xml", response);
 		then(response).containsText(bundleElem(
-				bundleResourceElem("rootElem2", rootElem2(templateElem(mergeElem("id2")))),
-				bundleResourceElem("rootElem", rootElem(templateElem(mergeElem("id1"))))
+				bundleResourceElem("rootElem", rootElem(templateElem(mergeElem("id1")))),
+				bundleResourceElem("rootElem2", rootElem2(templateElem(mergeElem("id2"))))
 			));
 	}
 	


### PR DESCRIPTION
This is a non-functional change which has no acceptance criteria apart from the fact it shouldn't break anything. The change was only made since this order affects whether tests will pass or fail, and makes the program easier to reason about.
