### PR TITLE
preventing brjs.conf from being written any time a command is run

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/BRJS.java
@@ -151,7 +151,9 @@ public class BRJS extends AbstractBRJSRootNode
 	public void populate() throws InvalidNameException, ModelUpdateException {
 		try {
 			super.populate();
-			bladerunnerConf().write();
+			if (!bladerunnerConf().fileExists()) {
+				bladerunnerConf().write();
+			}
 		}
 		catch (ConfigException e) {
 			if(e.getCause() instanceof InvalidNameException) {


### PR DESCRIPTION
changing `brjs.populate` so it checks whether `brjs.conf` exists before writing it. fixes #884
