### PR TITLE
explicitly cleaning up temporary directories

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/memoization/MemoizedFileTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/memoization/MemoizedFileTest.java
@@ -9,15 +9,29 @@ import org.bladerunnerjs.model.BRJS;
 import org.bladerunnerjs.model.BRJSTestModelFactory;
 import org.bladerunnerjs.model.exception.InvalidSdkDirectoryException;
 import org.bladerunnerjs.utility.FileUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 
 public class MemoizedFileTest
 {
 
+	private File tempDir;
+
+	@Before
+	public void setup() throws IOException {
+		tempDir = FileUtils.createTemporaryDirectory(this.getClass());
+	}
+	
+	@After
+	public void cleanup() {
+		org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
+	}
+	
 	@Test
 	public void testRelativePaths() throws InvalidSdkDirectoryException, IOException {
-		BRJS brjs = BRJSTestModelFactory.createModel( FileUtils.createTemporaryDirectory(this.getClass()) );
+		BRJS brjs = BRJSTestModelFactory.createModel( tempDir );
 		assertEquals("child", brjs.getMemoizedFile(new File(".")).getRelativePath(brjs.getMemoizedFile(new File("child"))));
 		assertEquals("child/grandchild", brjs.getMemoizedFile(new File(".")).getRelativePath(brjs.getMemoizedFile(new File("child/grandchild"))));
 		assertEquals("../child/grandchild", brjs.getMemoizedFile(new File(".")).getRelativePath(brjs.getMemoizedFile(new File("../child/grandchild"))));

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/memoization/MemoizedValueTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/memoization/MemoizedValueTest.java
@@ -35,6 +35,7 @@ public class MemoizedValueTest {
 	@After
 	public void tearDown() {
 		brjs.close();
+		org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
 	}
 	
 	@Test

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/model/BRJSUnitTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/model/BRJSUnitTest.java
@@ -13,20 +13,22 @@ import org.junit.Test;
 public class BRJSUnitTest 
 {
 	private BRJS brjs;
+	private File testSdkDirectory;
 	
 	@Before
 	public void setup() throws Exception
 	{
-		File rootDir = FileUtils.createTemporaryDirectory( this.getClass() );
-		new File(rootDir, "sdk").mkdir();
+		testSdkDirectory = FileUtils.createTemporaryDirectory( this.getClass() );
+		new File(testSdkDirectory, "sdk").mkdir();
 		
-		brjs = BRJSTestModelFactory.createModel(rootDir);
+		brjs = BRJSTestModelFactory.createModel(testSdkDirectory);
 	}
 	
 	@After
 	public void teardown()
 	{
 		brjs.close();
+		org.apache.commons.io.FileUtils.deleteQuietly(testSdkDirectory);
 	}
 	
 	@Test

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/model/IOTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/model/IOTest.java
@@ -36,6 +36,7 @@ public class IOTest {
 	@After
 	public void tearDown() {
 		io.uninstallFileAccessChecker();
+		org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
 	}
 	
 	@Test

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/model/engine/NodeTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/model/engine/NodeTest.java
@@ -13,6 +13,7 @@ import org.bladerunnerjs.testing.utility.LogMessageStore;
 import org.bladerunnerjs.testing.utility.TestLoggerFactory;
 import org.bladerunnerjs.utility.FileUtils;
 import org.bladerunnerjs.utility.ObserverList;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,6 +32,15 @@ public class NodeTest
 	
 	private static final String TEST_DIR = "src/test/resources/NodeTest";
 	private RootNode mockRootNode = new MockRootNode();
+	
+	private File tempDir;
+	
+	@After
+	public void tearDown() {
+		if (tempDir != null) {
+			org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
+		}
+	}
 	
 	@Test
 	public void rootNodeIsReturned() throws Exception
@@ -93,7 +103,7 @@ public class NodeTest
 	@Test
 	public void createPathShouldCauseAllNecesarrySubDirectoriesToBeCreated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File childDir = new File(tempDir, "child");
 		File grandchildDir = new File(childDir, "grandchild");
 		File greatGrandchildDir = new File(grandchildDir, "great-grandchild");
@@ -125,7 +135,7 @@ public class NodeTest
 	@Test
 	public void deleteShouldCauseTheDirectoryToBeDeletedIfItExists() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File childDir = new File(rootDir, "child");
 		
@@ -144,7 +154,7 @@ public class NodeTest
 	@Test
 	public void deleteShouldWorkEvenWhenTheDirectoryIsNonEmpty() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		
 		rootDir.mkdir();
@@ -160,23 +170,23 @@ public class NodeTest
 	@Test
 	public void constructingARootNodeShouldLocateTheRootAncestorDirectory() throws Exception
 	{
-		File rootDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
-		TestRootNode rootNode = new TestRootNode(new File(rootDir, "child-dir"));
+		tempDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
+		TestRootNode rootNode = new TestRootNode(new File(tempDir, "child-dir"));
 		
-		assertEquals(rootDir.getPath(), rootNode.dir().getPath());
+		assertEquals(tempDir.getPath(), rootNode.dir().getPath());
 	}
 	
 	@Test
 	public void locateAncestorNodeOfClassShouldSucceedIfOneOfTheAncestorsIsACachedNode() throws Exception
 	{
-		File rootDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
-		File childDir = new File(rootDir, "child");
+		tempDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
+		File childDir = new File(tempDir, "child");
 		File grandchildDir = new File(childDir, "grandchild");
 		File greatGrandchildDir = new File(grandchildDir, "greatgrandchild");
 		
 		childDir.mkdir();
 		grandchildDir.mkdir();
-		TestRootNode rootNode = new TestRootNode(rootDir);
+		TestRootNode rootNode = new TestRootNode(tempDir);
 		
 		// add node to cache
 		TestNode child = new TestNode(rootNode, null, childDir);
@@ -193,13 +203,13 @@ public class NodeTest
 	@Test
 	public void locateAncestorNodeOfClassShouldReturnNullIfNoneOfTheAncestorsAreCachedNodes() throws Exception
 	{
-		File rootDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
-		File childDir = new File(rootDir, "child");
+		tempDir = FileUtils.createTemporaryDirectory( this.getClass(), "brjs-root-node" );
+		File childDir = new File(tempDir, "child");
 		File grandchildDir = new File(childDir, "grandchild");
 		
 		childDir.mkdir();
 		grandchildDir.mkdir();
-		TestRootNode rootNode = new TestRootNode(rootDir);
+		TestRootNode rootNode = new TestRootNode(tempDir);
 		
 		assertNull(rootNode.locateAncestorNodeOfClass(childDir, TestNode.class));
 		assertNull(rootNode.locateAncestorNodeOfClass(grandchildDir, TestNode.class));
@@ -359,7 +369,7 @@ public class NodeTest
 	@Test
 	public void requestingAllChildrenAgainReturnsDifferentResultsIfTheFilesOnDiskHaveChanged() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		
 		rootDir.mkdir();
@@ -376,7 +386,7 @@ public class NodeTest
 	@Test
 	public void theChildrenOnlyIncludeDirectories() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File child1 = new File(rootDir, "child-1");
 		File child2 = new File(rootDir, "child-2");
@@ -392,7 +402,7 @@ public class NodeTest
 	@Test
 	public void theChildrenOnlyIncludeDirectoriesThatMatchTheFileNameFilter() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File child1 = new File(rootDir, "child-1");
 		File child2 = new File(rootDir, "child2");
@@ -419,7 +429,7 @@ public class NodeTest
 	@Test
 	public void cachedNonExistentItemsWillLaterBeUsedIfTheItemSubsequentlyComesIntoExistence() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File child1 = new File(rootDir, "child-1");
 		File child2 = new File(rootDir, "child-2");
@@ -445,7 +455,7 @@ public class NodeTest
 	@Test
 	public void existentSingleItemNodesCanBeNavigated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File itemDir = new File(rootDir, "single-item");
 		itemDir.mkdirs();
@@ -461,7 +471,7 @@ public class NodeTest
 	@Test
 	public void nonExistentSingleItemNodesCanBeNavigated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File itemDir = new File(rootDir, "single-item");
 		rootDir.mkdir();
@@ -473,7 +483,7 @@ public class NodeTest
 	@Test
 	public void nonExistentSingleItemNodesCanNotBeLocated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File itemDir = new File(rootDir, "single-item");
 		
@@ -487,7 +497,7 @@ public class NodeTest
 	@Test
 	public void existentSingleItemNodesCanBeLocated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File itemDir = new File(rootDir, "single-item");
 		
@@ -502,7 +512,7 @@ public class NodeTest
 	@Test
 	public void nonExistentMultiLocationSingleItemNodesCanBeNavigated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primaryItemDir = new File(rootDir, "single-item-primary-location");
 		rootDir.mkdir();
@@ -514,7 +524,7 @@ public class NodeTest
 	@Test
 	public void multiLocationSingleItemNodesCanBeNavigatedWhenAtThePrimaryLocation() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primaryItemDir = new File(rootDir, "single-item-primary-location");
 		primaryItemDir.mkdirs();
@@ -527,7 +537,7 @@ public class NodeTest
 	@Test
 	public void multiLocationSingleItemNodesCanBeNavigatedWhenAtTheSecondaryLocation() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File secondaryItemDir = new File(rootDir, "single-item-secondary-location");
 		secondaryItemDir.mkdirs();
@@ -540,7 +550,7 @@ public class NodeTest
 	@Test(expected=BladeRunnerDirectoryException.class)
 	public void multiLocationSingleItemNodesThrowAnExceptionIfDefinedAtBothLocations() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primaryItemDir = new File(rootDir, "single-item-primary-location");
 		File secondaryItemDir = new File(rootDir, "single-item-secondary-location");
@@ -555,7 +565,7 @@ public class NodeTest
 	@Test
 	public void nonExistentMultiLocationSingleItemNodesCanNotBeLocated() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primaryItemDir = new File(rootDir, "single-item-primary-location");
 		rootDir.mkdir();
@@ -569,7 +579,7 @@ public class NodeTest
 	@Test
 	public void multiLocationSingleItemNodesCanBeLocatedWhenAtThePrimaryLocation() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primaryItemDir = new File(rootDir, "single-item-primary-location");
 		primaryItemDir.mkdirs();
@@ -584,7 +594,7 @@ public class NodeTest
 	@Test
 	public void multiLocationSingleItemNodesCanBeLocatedWhenAtTheSecondaryLocation() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File secondaryItemDir = new File(rootDir, "single-item-secondary-location");
 		secondaryItemDir.mkdirs();
@@ -599,7 +609,7 @@ public class NodeTest
 	@Test
 	public void multiLocationItemSetNodesCanBeNavigatedWhenItemsPresentInOneSideOnly() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primarySetDir = new File(rootDir, "set-primary-location");
 		File child1Dir = new File(primarySetDir, "child-1");
@@ -618,7 +628,7 @@ public class NodeTest
 	@Test
 	public void multiLocationItemSetCanBeNavigatedWhenListPlusList() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primarySetDir = new File(rootDir, "set-primary-location");
 		File secondarySetDir = new File(rootDir, "set-secondary-location");
@@ -644,7 +654,7 @@ public class NodeTest
 	@Test
 	public void multiLocationItemSetNodesCanBeNavigatedWhenItemPlusList() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primarySetDir = new File(rootDir, "set-primary-location");
 		File singleItemSetDir = new File(rootDir, "set-single-item-location");
@@ -667,7 +677,7 @@ public class NodeTest
 	@Test(expected=BladeRunnerDirectoryException.class)
 	public void multiLocationItemSetNodesThrowAnExceptionOnNavigationIfTheSameNameIsDefinedTwice() throws Exception
 	{
-		File tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
+		tempDir = FileUtils.createTemporaryDirectory( NodeTest.class );
 		File rootDir = new File(tempDir, "brjs-root-node");
 		File primarySetDir = new File(rootDir, "set-primary-location");
 		File singleItemSetDir = new File(rootDir, "set-single-item-location");

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/BuildAppTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/BuildAppTest.java
@@ -11,6 +11,7 @@ import org.bladerunnerjs.testing.utility.MockContentPlugin;
 import org.bladerunnerjs.testing.utility.ScriptedContentPlugin;
 import org.bladerunnerjs.testing.utility.ScriptedRequestGeneratingTagHandlerPlugin;
 import org.bladerunnerjs.utility.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +33,11 @@ public class BuildAppTest extends SpecTest {
 			nonDefaultAspect = app.aspect("aspect2");
 			targetDir = FileUtils.createTemporaryDirectory( this.getClass() );
 			bladerunnerConf = brjs.bladerunnerConf();
+	}
+	
+	@After
+	public void deleteTempDir() {
+		org.apache.commons.io.FileUtils.deleteQuietly(targetDir);
 	}
 	
 	@Test

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/utility/TagPluginUtilityTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/utility/TagPluginUtilityTest.java
@@ -34,6 +34,9 @@ public class TagPluginUtilityTest
 	BRJS brjs;
 	App app;
 	Aspect aspect;
+
+
+	private File testSdkDirectory;
 	
 	@Before
 	public void setup() throws Exception
@@ -54,8 +57,8 @@ public class TagPluginUtilityTest
 		/* asset location support */
 		mockPluginLocator.assetLocationPlugins.add(new VirtualProxyAssetLocationPlugin(new BRJSConformantAssetLocationPlugin()));
 		
-		File tempDir = BRJSTestModelFactory.createTestSdkDirectory();
-		brjs = BRJSTestModelFactory.createModel(tempDir, mockPluginLocator);
+		testSdkDirectory = BRJSTestModelFactory.createTestSdkDirectory();
+		brjs = BRJSTestModelFactory.createModel(testSdkDirectory, mockPluginLocator);
 		
 		app = brjs.app("app");
 			app.create();
@@ -66,6 +69,7 @@ public class TagPluginUtilityTest
 	@After
 	public void tearDown() {
 		brjs.close();
+		org.apache.commons.io.FileUtils.deleteQuietly(testSdkDirectory);
 	}
 	
 	@Test

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/NodeImporter.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/NodeImporter.java
@@ -40,21 +40,25 @@ public class NodeImporter {
 		BRJS tempBrjs = createTemporaryBRJSModel();
 		
 		File temporaryUnzipDir = FileUtils.createTemporaryDirectory( NodeImporter.class, targetApp.getName() );
-		ZipUtility.unzip(sourceAppZip, temporaryUnzipDir );
-		File[] temporaryUnzipDirFiles = temporaryUnzipDir.listFiles();
-		if (temporaryUnzipDirFiles.length != 1) {
-			throw new IOException("Exepected to find 1 folder inside the provided zip, there was " + temporaryUnzipDirFiles.length);
+		try {
+    		ZipUtility.unzip(sourceAppZip, temporaryUnzipDir );
+    		File[] temporaryUnzipDirFiles = temporaryUnzipDir.listFiles();
+    		if (temporaryUnzipDirFiles.length != 1) {
+    			throw new IOException("Exepected to find 1 folder inside the provided zip, there was " + temporaryUnzipDirFiles.length);
+    		}
+    		
+    		App tmpBrjsSourceApp = tempBrjs.app( targetApp.getName() );
+    		File unzippedAppDir = temporaryUnzipDirFiles[0];
+    		FileUtils.moveDirectory(tmpBrjsSourceApp, unzippedAppDir, tmpBrjsSourceApp.dir());
+    		
+    		File unzippedLibDir = tmpBrjsSourceApp.file("WEB-INF/lib");
+    		FileUtils.copyDirectory(targetApp, targetApp.root().appJars().dir(), unzippedLibDir);
+    		
+    		String sourceAppName = unzippedAppDir.getName();
+    		importApp(tempBrjs, sourceAppName, tmpBrjsSourceApp, targetApp, targetAppRequirePrefix);
+		} finally {
+			org.apache.commons.io.FileUtils.deleteQuietly(temporaryUnzipDir);
 		}
-		
-		App tmpBrjsSourceApp = tempBrjs.app( targetApp.getName() );
-		File unzippedAppDir = temporaryUnzipDirFiles[0];
-		FileUtils.moveDirectory(tmpBrjsSourceApp, unzippedAppDir, tmpBrjsSourceApp.dir());
-		
-		File unzippedLibDir = tmpBrjsSourceApp.file("WEB-INF/lib");
-		FileUtils.copyDirectory(targetApp, targetApp.root().appJars().dir(), unzippedLibDir);
-		
-		String sourceAppName = unzippedAppDir.getName();
-		importApp(tempBrjs, sourceAppName, tmpBrjsSourceApp, targetApp, targetAppRequirePrefix);
 	}
 	
 	public static void importApp(BRJS tempBrjs, String oldAppName, App sourceApp, App targetApp, String targetAppRequirePrefix) throws InvalidSdkDirectoryException, IOException, ConfigException {
@@ -110,14 +114,17 @@ public class NodeImporter {
 	}
 	
 	private static BRJS createTemporaryBRJSModel() throws InvalidSdkDirectoryException, IOException {
+		BRJS brjs;
 		File tempSdkDir = FileUtils.createTemporaryDirectory(NodeImporter.class);
-		new File(tempSdkDir, "sdk").mkdir();
-		MockPluginLocator pluginLocator = new MockPluginLocator();
-		pluginLocator.assetLocationPlugins.addAll(PluginLoader.createPluginsOfType(Mockito.mock(BRJS.class), AssetLocationPlugin.class, VirtualProxyAssetLocationPlugin.class));
-		pluginLocator.assetPlugins.addAll(PluginLoader.createPluginsOfType(Mockito.mock(BRJS.class), AssetPlugin.class, VirtualProxyAssetPlugin.class));
-		
-		BRJS brjs = new BRJS(tempSdkDir, pluginLocator, new StubLoggerFactory(), new MockAppVersionGenerator());
-		
+		try {
+    		new File(tempSdkDir, "sdk").mkdir();
+    		MockPluginLocator pluginLocator = new MockPluginLocator();
+    		pluginLocator.assetLocationPlugins.addAll(PluginLoader.createPluginsOfType(Mockito.mock(BRJS.class), AssetLocationPlugin.class, VirtualProxyAssetLocationPlugin.class));
+    		pluginLocator.assetPlugins.addAll(PluginLoader.createPluginsOfType(Mockito.mock(BRJS.class), AssetPlugin.class, VirtualProxyAssetPlugin.class));
+    		brjs = new BRJS(tempSdkDir, pluginLocator, new StubLoggerFactory(), new MockAppVersionGenerator());
+		} finally {
+			org.apache.commons.io.FileUtils.deleteQuietly(tempSdkDir);
+		}
 		return brjs;
 	}
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/app/building/StaticAppBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/app/building/StaticAppBuilder.java
@@ -19,11 +19,14 @@ public class StaticAppBuilder implements AppBuilder {
 		try
 		{
 			FileUtils.moveDirectoryContents(app.root(), exportDir, appBuildDir);
-			org.apache.commons.io.FileUtils.deleteQuietly(exportDir);
 		}
 		catch (IOException ex)
 		{
 			throw new ModelOperationException(ex);
+		}
+		finally 
+		{
+			org.apache.commons.io.FileUtils.deleteQuietly(exportDir);			
 		}
 	}
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTest.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/testing/specutility/engine/SpecTest.java
@@ -8,6 +8,7 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.bladerunnerjs.aliasing.aliasdefinitions.AliasDefinitionsFile;
 import org.bladerunnerjs.aliasing.aliases.AliasesFile;
 import org.bladerunnerjs.appserver.ApplicationServer;
@@ -115,6 +116,7 @@ public abstract class SpecTest
 		logging = new LogMessageStore();
 		exceptions = new ArrayList<>();
 		observer = mock(EventObserver.class);
+		if (testSdkDirectory != null) FileUtils.deleteQuietly(testSdkDirectory);
 		testSdkDirectory = BRJSTestModelFactory.createTestSdkDirectory();
 		pluginLocator = new MockPluginLocator();
 		webappTester = new WebappTester(testSdkDirectory);

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/TemplateUtility.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/TemplateUtility.java
@@ -107,6 +107,7 @@ public class TemplateUtility
 		finally {
 			if (tempDir != null) {
 				FileUtils.deleteQuietly(node.root(), tempDir);
+				org.apache.commons.io.FileUtils.deleteQuietly(tempDir);
 			}
 		}
 	}

--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/CmdCreator.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/test/testrunner/CmdCreator.java
@@ -3,7 +3,6 @@ package com.caplin.cutlass.command.test.testrunner;
 import java.io.File;
 import java.util.Formatter;
 
-import org.bladerunnerjs.model.BRJS;
 
 public class CmdCreator {
 	public static String[] cmd(File sdkDir, String cmd, Object... parameters) {

--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/TestCompiler.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/TestCompiler.java
@@ -51,6 +51,8 @@ public class TestCompiler
 			catch (IOException ex)
 			{
 				throw new CommandOperationException("Error creating directory for compiled tests.", ex);
+			} finally {
+				org.apache.commons.io.FileUtils.deleteQuietly(compiledClassDir);
 			}
 			
 			// see http://help.eclipse.org/helios/index.jsp?topic=/org.eclipse.jdt.doc.isv/guide/jdt_api_compile.htm for command line args

--- a/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/TestIntegrationCommand.java
+++ b/cutlass-tasks/src/main/java/com/caplin/cutlass/command/testIntegration/TestIntegrationCommand.java
@@ -84,9 +84,9 @@ public class TestIntegrationCommand extends AbstractPlugin implements LegacyComm
 		{
 			throw new CommandOperationException("Error creating directory for compiled tests.", ex);
 		}
-		if (classesRoot.exists()) 
-		{
+		finally {
 			FileUtils.deleteQuietly(brjs, classesRoot);
+			org.apache.commons.io.FileUtils.deleteQuietly(classesRoot);
 		}
 		
 		List<File> testContainerDirs = new IntegrationTestFinder().findTestContainerDirs(brjs, testRoot, ignoreWorkbenches(args));

--- a/system-app-servlets/src/main/java/com/caplin/cutlass/app/servlet/RestApiServlet.java
+++ b/system-app-servlets/src/main/java/com/caplin/cutlass/app/servlet/RestApiServlet.java
@@ -154,15 +154,19 @@ public class RestApiServlet extends HttpServlet
 			else if (EXPORT_APP_PATTERN.matcher(requestPath).matches())
 			{
 				File targetDir = FileUtils.createTemporaryDirectory( this.getClass() );
-				File warTempFile = new File(targetDir, "x.war");
-				apiService.exportWar(appName, brjs.getMemoizedFile(warTempFile));
-				response.setContentType("application/octet-stream");
-				response.setHeader("Content-Disposition", "attachment; filename=\""+appName+".war\"");
-				
-				response.addHeader("Content-Length", Long.toString(warTempFile.length()));
-				
-				IOUtils.copy(new FileInputStream(warTempFile), response.getOutputStream());
-				response.flushBuffer();
+				try {
+    				File warTempFile = new File(targetDir, "x.war");
+    				apiService.exportWar(appName, brjs.getMemoizedFile(warTempFile));
+    				response.setContentType("application/octet-stream");
+    				response.setHeader("Content-Disposition", "attachment; filename=\""+appName+".war\"");
+    				
+    				response.addHeader("Content-Length", Long.toString(warTempFile.length()));
+    				
+    				IOUtils.copy(new FileInputStream(warTempFile), response.getOutputStream());
+    				response.flushBuffer();
+				} finally {
+					org.apache.commons.io.FileUtils.deleteQuietly(targetDir);
+				}
 				return;
 			}
 			else if (RELASE_NOTE_PATTERN.matcher(requestPath).matches())


### PR DESCRIPTION
explicitly cleaning up temporary directories rather than relying on the
shutdown hook to do it since it seems JVM shutdown hooks sometimes arent
triggered when running via Eclipse

<!---
@huboard:{"order":1137.5,"milestone_order":1202,"custom_state":""}
-->
