### PR TITLE
Xml file lock reproduction attempt

### DIFF
--- a/brjs-sdk/conf/bundleConfig.xml
+++ b/brjs-sdk/conf/bundleConfig.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<bundleConfig xmlns="http://schema.caplin.com/CaplinTrader/bundleConfig">
+	<resource
+		rootElement="gridDefinitions"
+		templateElements="dataProviderMappings, decoratorMappings, templates, grids"
+		mergeElements="dataProviderMapping, decoratorMapping, gridTemplate, folder@name, grid"
+	/>
+</bundleConfig>

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,20 +2,18 @@
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
-	
+
 repositories {
 	mavenCentral()
-	maven {
-		url "http://snapshots.repository.codehaus.org/"
-	}
-}	
+}
 
 dependencies {
 	compile localGroovy()
-	
+
 	compile gradleApi()
 	compile 'commons-io:commons-io:2.3'
 	compile 'org.apache.httpcomponents:httpclient:4.2.1'
 	compile 'org.apache.commons:commons-lang3:3.1'
-	compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7-SNAPSHOT'
+	compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XmlBundleWriter.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/plugins/bundlers/xml/XmlBundleWriter.java
@@ -74,7 +74,7 @@ public class XmlBundleWriter
 							siblingReader.close();
 						}
 						catch(XMLStreamException e) {
-							// do nothing: we want to close as many readers as possible
+							System.out.println("bingo!");
 						}
 					}
 				}


### PR DESCRIPTION
This commit contains my failed attempt to replicate #446. In addition to these changes I created a new app with the namespace `appx`, and containing a single blade in the default bladeset named `myblade`.

Additionally, I added this to the app's `index.html`:

```js
require('appx/myblade/MybladeViewModel');
var XmlResourceService = require('br/services/xml/BRXmlResourceService');
(new XmlResourceService()).getXmlDocument('gridDefinitions');
```

this inside `resources/xml/gridDef1.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<gridDefinitions xmlns="http://schema.caplin.com/CaplinTrader/gridDefinitions">
	<grids>
		<grid id="appx.equities.london" displayName="@{appx.layout.caption.equities.london}" baseTemplate="caplinx.fxtrader.london.equitiesGrid">
			<gridRowModel>
				<caplin.sljs-container-grid-data-provider container="/CONTAINER/EQ/London"/>
			</gridRowModel>
		</grid>
	</grids>
</gridDefinitions>
```

and this inside `blades/myblade/resources/xml/gridDef2.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<gridDefinitions xmlns="http://schema.caplin.com/CaplinTrader/gridDefinitions">
	<grids>
		<grid id="appx.myblade.gridexpandable.fiALL" displayName="FI ALL" baseTemplate="appx.myblade.fiGrid">
			<gridRowModel>
				<caplin.sljs-container-grid-data-provider container="/CONTAINER/FI/ALL"/>
			</gridRowModel>
		</grid>
	</grids>
</gridDefinitions>
```

Then, with these changes made, I tried modifying both files then refreshing the page while while `brjs serve` was left running. I suspect this bug only occurs on Windows.
