### PR TITLE
Datepicker control enhancements

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
@@ -2,7 +2,7 @@
  * @module br/presenter/control/datefield/JQueryDatePickerControl
  */
 
-br.Core.thirdparty("jquery");
+br.Core.thirdparty('jquery');
 
 var MapUtility = require('br/util/MapUtility');
 var EventUtility = require('br/util/EventUtility');
@@ -74,12 +74,12 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.setOptions = fu
 br.presenter.control.datefield.JQueryDatePickerControl.prototype.setPresentationNode = function(oPresentationNode)
 {
 	if(!(oPresentationNode instanceof br.presenter.node.DateField)) {
-		throw new br.presenter.control.InvalidControlModelError("JQueryDatePickerControl", "DateField");
+		throw new br.presenter.control.InvalidControlModelError('JQueryDatePickerControl', 'DateField');
 	}
 
 	this.m_oPresentationNode = oPresentationNode;
-	this.m_oPresentationNode.enabled.addChangeListener(this, "_setDisabled");
-	this.m_oPresentationNode.visible.addChangeListener(this, "_setVisible");
+	this.m_oPresentationNode.enabled.addChangeListener(this, '_setDisabled');
+	this.m_oPresentationNode.visible.addChangeListener(this, '_setVisible');
 	this.m_oPresentationNode.value.addChangeListener(this, '_setValue');
 };
 
@@ -140,7 +140,7 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._setDisabled = 
 br.presenter.control.datefield.JQueryDatePickerControl.prototype._setVisible = function()
 {
 	var bVisible = this.m_oPresentationNode.visible.getValue();
-	this.m_oJQueryNode[0].parentNode.style.display = (bVisible) ? "block" : "none";
+	this.m_oJQueryNode[0].parentNode.style.display = (bVisible) ? 'block' : 'none';
 };
 
 /**
@@ -159,7 +159,7 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._generateCalend
 	var oThis = this;
 	var oOptions = MapUtility.mergeMaps([{
 		showOn: 'button',
-		dateFormat: "yy-mm-dd",
+		dateFormat: 'yy-mm-dd',
 		disabled: !this.m_oPresentationNode.enabled.getValue(),
 		onSelect: function(dateText)
 		{

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
@@ -5,6 +5,7 @@
 br.Core.thirdparty("jquery");
 
 var MapUtility = require('br/util/MapUtility');
+var EventUtility = require('br/util/EventUtility');
 
 /**
  * @class
@@ -39,6 +40,9 @@ br.presenter.control.datefield.JQueryDatePickerControl = function()
 
 	/** @private */
 	this.m_eElement = null;
+
+	/** @private */
+	this.m_aListeners = [];
 };
 
 br.Core.inherit(br.presenter.control.datefield.JQueryDatePickerControl, br.presenter.control.ControlAdaptor);
@@ -89,6 +93,9 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.destroy = funct
 	this.m_oPresentationNode.removeChildListeners();
 
 	this.m_oPresentationNode = null;
+	this.m_aListeners.forEach(function(listener) {
+		EventUtility.removeEventListener(listener);
+	});
 };
 
 /**
@@ -107,6 +114,10 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.onViewReady = f
 	}
 
 	this._generateCalendarHtml();
+
+	if (this.m_mOptions.stopPropagation) {
+		this._stopPropagation();
+	}
 
 	this._setVisible();
 	this._setValue();
@@ -161,4 +172,16 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._generateCalend
 	}, this.m_mOptions], true);
 
 	this.m_oJQueryNode.datepicker(oOptions);
+};
+
+/**
+ * @private
+ */
+br.presenter.control.datefield.JQueryDatePickerControl.prototype._stopPropagation = function() 
+{
+	setTimeout(function() {
+		var eElement = this.m_oJQueryNode.data('datepicker').dpDiv[0];
+		this.m_aListeners.push(EventUtility.addEventListener(eElement, 'click', EventUtility.stopPropagation));
+		this.m_aListeners.push(EventUtility.addEventListener(eElement, 'mouseup', EventUtility.stopPropagation));
+	}.bind(this), 0);
 };

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
@@ -5,7 +5,6 @@
 br.Core.thirdparty('jquery');
 
 var MapUtility = require('br/util/MapUtility');
-var EventUtility = require('br/util/EventUtility');
 
 /**
  * @class
@@ -40,9 +39,6 @@ br.presenter.control.datefield.JQueryDatePickerControl = function()
 
 	/** @private */
 	this.m_eElement = null;
-
-	/** @private */
-	this.m_aListeners = [];
 };
 
 br.Core.inherit(br.presenter.control.datefield.JQueryDatePickerControl, br.presenter.control.ControlAdaptor);
@@ -93,9 +89,6 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.destroy = funct
 	this.m_oPresentationNode.removeChildListeners();
 
 	this.m_oPresentationNode = null;
-	this.m_aListeners.forEach(function(listener) {
-		EventUtility.removeEventListener(listener);
-	});
 };
 
 /**
@@ -114,10 +107,6 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.onViewReady = f
 	}
 
 	this._generateCalendarHtml();
-
-	if (this.m_mOptions.stopPropagation) {
-		this._stopPropagation();
-	}
 
 	this._setVisible();
 	this._setValue();
@@ -172,16 +161,4 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._generateCalend
 	}, this.m_mOptions], true);
 
 	this.m_oJQueryNode.datepicker(oOptions);
-};
-
-/**
- * @private
- */
-br.presenter.control.datefield.JQueryDatePickerControl.prototype._stopPropagation = function() 
-{
-	setTimeout(function() {
-		var eElement = this.m_oJQueryNode.data('datepicker').dpDiv[0];
-		this.m_aListeners.push(EventUtility.addEventListener(eElement, 'click', EventUtility.stopPropagation));
-		this.m_aListeners.push(EventUtility.addEventListener(eElement, 'mouseup', EventUtility.stopPropagation));
-	}.bind(this), 0);
 };

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
@@ -4,6 +4,8 @@
 
 br.Core.thirdparty("jquery");
 
+var MapUtility = require('br/util/MapUtility');
+
 /**
  * @class
  * @alias module:br/presenter/control/datefield/JQueryDatePickerControl
@@ -105,7 +107,7 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype.onViewReady = f
 	}
 
 	this._generateCalendarHtml();
-	this.m_oJQueryNode.datepicker("option", this.m_mOptions);
+
 	this._setVisible();
 	this._setValue();
 };
@@ -144,9 +146,7 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._setValue = fun
 br.presenter.control.datefield.JQueryDatePickerControl.prototype._generateCalendarHtml = function()
 {
 	var oThis = this;
-
-	this.m_oJQueryNode.datepicker(
-	{
+	var oOptions = MapUtility.mergeMaps([{
 		showOn: 'button',
 		dateFormat: "yy-mm-dd",
 		disabled: !this.m_oPresentationNode.enabled.getValue(),
@@ -156,7 +156,9 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._generateCalend
 		},
 		beforeShow:function()
 		{
-			oThis.m_oJQueryNode.datepicker("setDate", oThis.m_oPresentationNode.value.getValue());
+			oThis._setValue();
 		}
-	});
+	}, this.m_mOptions], true);
+
+	this.m_oJQueryNode.datepicker(oOptions);
 };

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerControlTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerControlTest.js
@@ -3,9 +3,10 @@ JQueryDatePickerControlTest = TestCase("JQueryDatePickerControlTest");
 JQueryDatePickerControlTest.prototype.setUp = function()
 {
 	this.m_oControlAdaptor = new br.presenter.control.datefield.JQueryDatePickerControl();
-	this.m_oControlAdaptor.m_oJQueryNode.datepicker = function(){
-		// do nothing
-	};
+	var eElement = document.createElement('div');
+	document.body.appendChild(eElement);
+
+	this.m_oControlAdaptor.setElement(eElement);
 };
 
 JQueryDatePickerControlTest.prototype.test_datePickerCanBeBoundToDateField = function()
@@ -32,4 +33,84 @@ JQueryDatePickerControlTest.prototype.test_datePickerThrowsExceptionIfBoundToVan
 	assertException(function() {
 		oThis.m_oControlAdaptor.setPresentationNode(oField);
 	}, "InvalidControlModelError");
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerInitialisesWithCorrectDateFormat = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	assertEquals('yy-mm-dd', this.m_oControlAdaptor.m_oJQueryNode.datepicker('option', 'dateFormat'));
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerCanHaveOptionsOverridden = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.setOptions({
+		dateFormat: 'YYYYMMDD'
+	});
+
+	this.m_oControlAdaptor.onViewReady();
+
+	assertEquals('YYYYMMDD', this.m_oControlAdaptor.m_oJQueryNode.datepicker('option', 'dateFormat'));
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerInitialisesWithCorrectDate = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+	// 11th Feb 2015 in yy-mm-dd, the control's default format
+	oDateField.value.setValue('15-02-11');
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	assertEquals(2015, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getFullYear());
+	assertEquals(1, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getMonth()); // January is 0
+	assertEquals(11, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getDate());
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerDateUpdatesWhenPropertyChanges = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+	// 11th Feb 2015 in yy-mm-dd, the control's default format
+	oDateField.value.setValue('15-02-11');
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	// 23rd March 2016 in yy-mm-dd, the control's default format
+	oDateField.value.setValue('16-03-23');
+
+	assertEquals(2016, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getFullYear());
+	assertEquals(2, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getMonth()); // January is 0
+	assertEquals(23, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getDate());
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerStartsDisabledIfFieldIs = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+	oDateField.enabled.setValue(false);
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	assertTrue(this.m_oControlAdaptor.m_oJQueryNode.datepicker('isDisabled'));
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerIsDisabledWhenEnabledPropertyChanges = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	oDateField.enabled.setValue(false);
+	assertTrue(this.m_oControlAdaptor.m_oJQueryNode.datepicker('isDisabled'));
+
+	oDateField.enabled.setValue(true);
+	assertFalse(this.m_oControlAdaptor.m_oJQueryNode.datepicker('isDisabled'));
 };


### PR DESCRIPTION
This attempts to resolve three problems encountered with the jQuery datepicker control adapter.
 1. Inline datepickers are now supported with the 'inline' control option flag. http://jqueryui.com/datepicker/#inline
 2. Options are merged with defaults instead of being applied after initialisation with defaults.
 3. Datepicker click and mouseup events can be encapsulated with the 'stopPropagation' flag. http://stackoverflow.com/questions/22406505/jquery-ui-datepicker-next-and-prev-buttons-only-have-one-ancestor-e-target-p