### PR TITLE
Optionally parse ambiguous dates to end of month or year

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
@@ -67,7 +67,7 @@ br.formatting.DateFormatter.prototype.format = function(vValue, mAttributes) {
 /**
  * @private
  */
-br.formatting.DateFormatter.prototype.parseDate = function(vDate, sDateFormat)
+br.formatting.DateFormatter.prototype.parseDate = function(vDate, sDateFormat, bEndOfUnit)
 {
 	if (!vDate)
 	{
@@ -93,6 +93,9 @@ br.formatting.DateFormatter.prototype.parseDate = function(vDate, sDateFormat)
 			return moment(vDate*1000).toDate();
 		default:
 			var oMoment = moment(String(vDate), sDateFormat);
+			if (bEndOfUnit === true && sDateFormat.toLowerCase().indexOf('d') === -1) {
+				oMoment.endOf(sDateFormat === 'YYYY' ? 'year' : 'month');
+			}
 			var sValidationString = oMoment.format(sDateFormat);
 			return (sValidationString == String(vDate)) ? oMoment.toDate() : null;
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
@@ -31,34 +31,22 @@ br.Core.implement(br.formatting.DateFormatter, br.formatting.Formatter);
 /**
  * Formats a date by converting it from a specified input format to a new output format.
  *
- * <p>
- * Attribute Options:
- * </p>
- * <p>
- * <table>
- * <tr>
- * <th>Option</th>
- * <th>Description</th>
- * </tr>
- * <tr>
- * <td>inputFormat</td><td>  format of the input date, expressed with <a href="http://momentjs.com/docs/#/parsing/string-format/">Moment.js format tokens</a> (defaults to DD-MM-YYYY HH:mm:ss).</td></tr>
- * <tr><td>outputFormat</td><td>format of the output date, expressed with <a href="http://momentjs.com/docs/#/displaying/format/">Moment.js format tokens</a> (defaults to DD-MM-YYYY HH:mm:ss).</td></tr>
- * <tr><td>adjustForTimezone</td><td> boolean value representing whether the formatter should adjust the date according to the client's timezone</td></tr>
- * </table>
- *
- * @param {Variant} vValue  the input date (String or Date type).
- * @param {Map} mAttributes  the map of attributes.
+ * @param {string|Date} vValue the input date
+ * @param {object} mAttributes the map of attributes.
+ * @param {string} [mAttributes.inputFormat='DD-MM-YYYY HH:mm:ss'] format of the input date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} [mAttributes.outputFormat='DD-MM-YYYY HH:mm:ss'] format of the output date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {boolean} [mAttributes.adjustForTimezone=false] whether the formatter should adjust the date according to the client's timezone
  * @return  the output date.
  * @type String
  */
 br.formatting.DateFormatter.prototype.format = function(vValue, mAttributes) {
 	if (vValue) {
 		var sInputFormat = mAttributes["inputFormat"];
-		var bAdjustForTimezone = mAttributes["adjustForTimezone"] == "true" ? true : false;
+		var bAdjustForTimezone = mAttributes["adjustForTimezone"];
 		var oDate = this.parseDate(vValue, sInputFormat);
 		if (oDate) {
 			var sOutputFormat = mAttributes["outputFormat"];
-			vValue = this.formatDate(oDate, sOutputFormat, bAdjustForTimezone);
+			vValue = this.formatDate(oDate, sOutputFormat, mAttributes.adjustForTimezone);
 		}
 	}
 	return vValue;

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
@@ -67,7 +67,7 @@ br.parsing.DateParser.prototype.parse = function(vValue, mAttributes) {
 		var vDate = this._standardizeDateSeparators(vValue, mAttributes);
 		var pInputFormats = this._getAdmissibleInputFormats(mAttributes);
 		var sOutputFormat = mAttributes.outputFormat;
-		vValue = this._matchDate(vDate, pInputFormats, sOutputFormat);
+		vValue = this._matchDate(vDate, pInputFormats, sOutputFormat, mAttributes.endOfUnit);
 	}
 	return vValue;
 };
@@ -75,10 +75,10 @@ br.parsing.DateParser.prototype.parse = function(vValue, mAttributes) {
 /**
  * @private
  */
-br.parsing.DateParser.prototype._matchDate = function(vDate, pInputFormats, sOutputFormat) {
+br.parsing.DateParser.prototype._matchDate = function(vDate, pInputFormats, sOutputFormat, bEndOfUnit) {
 	for (var i = 0, n = pInputFormats.length; i < n; ++i) {
 		var sInputFormat = pInputFormats[i];
-		var oDate = this.m_oDateFormatter.parseDate(vDate, sInputFormat);
+		var oDate = this.m_oDateFormatter.parseDate(vDate, sInputFormat, bEndOfUnit);
 		if (oDate) {
 			return this.m_oDateFormatter.formatDate(oDate, sOutputFormat);
 		}

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
@@ -40,26 +40,14 @@ br.Core.implement(br.parsing.DateParser, br.parsing.Parser);
  * European: d-m-Y, d-m-Y, d-M-Y, d-M-Y, d-m<br/>
  * <p/>
  *
- * <p>
- * Attribute Options:
- * </p>
- * <p>
- * <table>
- * <tr>
- * <th>Option</th>
- * <th>Description</th>
- * </tr>
- * <tr>
- *
- * <td>american</td><td>  if true, dates are assumed to be in American format, i.e. month before date (defaults to false)</td></tr>
- * <tr><td>separators</td><td>  a set of admissible separator characters (defaults to "/.-")</td></tr>
- * <tr><td>inputFormats</td><td>  a comma separated list of admissible input formats</td></tr>
- * <tr><td>outputFormat</td><td>  the output date format</td></tr>
- * </table>
- *
- * @param {Variant} vValue  the date to parse (String).
- * @param {Map} mAttributes  the map of attributes.
- * @return  the date, expressed in the output format
+ * @param {string|Date} vValue the date to parse.
+ * @param {object} mAttributes the map of attributes.
+ * @param {boolean} [mAttributes.american=false] if true, dates are assumed to be in American format, i.e. month before date
+ * @param {string} [mAttributes.separators='/.-'] a set of admissible separator characters
+ * @param {string} mAttributes.inputFormats a comma separated list of admissible input formats
+ * @param {string} mAttributes.outputFormat the output date format
+ * @param {boolean} [mAttributes.endOfUnit=false] if true, parse ambiguous dates to the end of the month or year
+ * @return {string} the date, expressed in the output format
  * @type String
  */
 br.parsing.DateParser.prototype.parse = function(vValue, mAttributes) {

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/DateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/DateParserTest.js
@@ -138,6 +138,34 @@
 		this.assertParse("java", this.getMillisecondsSinceEpoch(this.oDateAtMidnight), "2010.11.12");
 	};
 
+	DateParserTest.prototype.test_parseAmbiguousInputToEndOfYear = function() {
+		var mAttributes = {
+			inputFormats: "YYYY",
+			outputFormat: "YYYYMMDD",
+			endOfUnit: true
+		};
+		this._assertParse("2015", "20151231", mAttributes);
+	};
+
+	DateParserTest.prototype.test_parseAmbiguousInputToEndOfMonth = function() {
+		var mAttributes = {
+			inputFormats: "MMM YYYY",
+			outputFormat: "YYYYMMDD",
+			endOfUnit: true
+		};
+		this._assertParse("Jan 2015", "20150131", mAttributes);
+	};
+
+	DateParserTest.prototype.test_parseUnambiguousDateWithEndOfUnitFlagDoesNotParseToEndOfUnit = function() {
+		var mAttributes = {
+			inputFormats: "DDMMYYYY",
+			outputFormat: "YYYYMMDD",
+			endOfUnit: true
+		};
+		this._assertParse("01012015", "20150101", mAttributes);
+	};
+
+
 	/*
 	* AMERICAN
 	*/


### PR DESCRIPTION
This is a reasonably generic enhancement required for some CT work.

If an ambiguous date (i.e. in a format that does not include the day of the month) is parsed, it will now optionally parse it to the end of the month or year, instead of always parsing it to the start.