### PR TITLE
Datepicker control should not update with invalid property

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/datefield/JQueryDatePickerControl.js
@@ -137,7 +137,9 @@ br.presenter.control.datefield.JQueryDatePickerControl.prototype._setVisible = f
  */
 br.presenter.control.datefield.JQueryDatePickerControl.prototype._setValue = function()
 {
-	this.m_oJQueryNode.datepicker('setDate', this.m_oPresentationNode.value.getValue());
+	if (this.m_oPresentationNode.value.hasValidationError() === false) {
+		this.m_oJQueryNode.datepicker('setDate', this.m_oPresentationNode.value.getValue());
+	}
 };
 
 /**

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerControlTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerControlTest.js
@@ -63,7 +63,7 @@ JQueryDatePickerControlTest.prototype.test_datePickerInitialisesWithCorrectDate 
 {
 	var oDateField = new br.presenter.node.DateField();
 	// 11th Feb 2015 in yy-mm-dd, the control's default format
-	oDateField.value.setValue('15-02-11');
+	oDateField.value.setValue('2015-02-11');
 
 	this.m_oControlAdaptor.setPresentationNode(oDateField);
 	this.m_oControlAdaptor.onViewReady();
@@ -77,13 +77,13 @@ JQueryDatePickerControlTest.prototype.test_datePickerDateUpdatesWhenPropertyChan
 {
 	var oDateField = new br.presenter.node.DateField();
 	// 11th Feb 2015 in yy-mm-dd, the control's default format
-	oDateField.value.setValue('15-02-11');
+	oDateField.value.setValue('2015-02-11');
 
 	this.m_oControlAdaptor.setPresentationNode(oDateField);
 	this.m_oControlAdaptor.onViewReady();
 
 	// 23rd March 2016 in yy-mm-dd, the control's default format
-	oDateField.value.setValue('16-03-23');
+	oDateField.value.setValue('2016-03-23');
 
 	assertEquals(2016, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getFullYear());
 	assertEquals(2, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getMonth()); // January is 0
@@ -113,4 +113,20 @@ JQueryDatePickerControlTest.prototype.test_datePickerIsDisabledWhenEnabledProper
 
 	oDateField.enabled.setValue(true);
 	assertFalse(this.m_oControlAdaptor.m_oJQueryNode.datepicker('isDisabled'));
+};
+
+JQueryDatePickerControlTest.prototype.test_datePickerRetainsLastValidValueWhenInvalidInputSupplied = function()
+{
+	var oDateField = new br.presenter.node.DateField();
+	// 11th Feb 2015 in yy-mm-dd, the control's default format
+	oDateField.value.setValue('2015-02-11');
+
+	this.m_oControlAdaptor.setPresentationNode(oDateField);
+	this.m_oControlAdaptor.onViewReady();
+
+	oDateField.value.setValue('invalid');
+
+	assertEquals(2015, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getFullYear());
+	assertEquals(1, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getMonth()); // January is 0
+	assertEquals(11, this.m_oControlAdaptor.m_oJQueryNode.datepicker('getDate').getDate());
 };


### PR DESCRIPTION
This is **not** required for the recent ct work that uses this control.

The datepicker control should not attempt to update its value with an invalid property. This can cause odd results with some invalid inputs, where the jQuery plugin manages to parse them to nonsensical dates.

e.g. "12345" in yymmdd is represented as December 2048 on the datepicker