### PR TITLE
Localised date parser and formatter

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-formatting/.js-style
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/.js-style
@@ -1,1 +1,0 @@
-namespaced-js

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
@@ -8,6 +8,7 @@ var Formatter = require('br/formatting/Formatter');
 var DateParsingUtil = require('br/parsing/DateParsingUtil');
 
 /**
+ * @deprecated The functionality provided by this formatter can be achieved more reliably with {@link module:br/formatting/LocalisedDateFormatter}
  * @class
  * @alias module:br/formatting/DateFormatter
  * @implements module:br/formatting/Formatter

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/DateFormatter.js
@@ -2,7 +2,10 @@
  * @module br/formatting/DateFormatter
  */
 
-br.Core.thirdparty("momentjs");
+var moment = require('momentjs');
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var DateParsingUtil = require('br/parsing/DateParsingUtil');
 
 /**
  * @class
@@ -21,9 +24,9 @@ br.Core.thirdparty("momentjs");
  *
  * See {@link module:br/presenter/parser/DateParser} for the complementary parser.
  */
-br.formatting.DateFormatter = function() {};
+function DateFormatter() {}
 
-br.Core.implement(br.formatting.DateFormatter, br.formatting.Formatter);
+topiarist.implement(DateFormatter, Formatter);
 
 /**
  * Formats a date by converting it from a specified input format to a new output format.
@@ -36,9 +39,9 @@ br.Core.implement(br.formatting.DateFormatter, br.formatting.Formatter);
  * @return  the output date.
  * @type String
  */
-br.formatting.DateFormatter.prototype.format = function(vValue, mAttributes) {
+DateFormatter.prototype.format = function(vValue, mAttributes) {
 	if (vValue) {
-		var oDate = br.parsing.DateParser.parseDate(vValue, mAttributes.inputFormat);
+		var oDate = DateParsingUtil.parse(vValue, mAttributes.inputFormat);
 		if (oDate) {
 			vValue = this.formatDate(oDate, mAttributes.outputFormat, mAttributes);
 		}
@@ -50,14 +53,14 @@ br.formatting.DateFormatter.prototype.format = function(vValue, mAttributes) {
  * @private
  * @deprecated
  */
-br.formatting.DateFormatter.prototype.parseDate = function(vDate, sDateFormat) {
-	return br.parsing.DateParser.parseDate(vDate, sDateFormat);
+DateFormatter.prototype.parseDate = function(vDate, sDateFormat) {
+	return DateParsingUtil.parse(vDate, sDateFormat);
 };
 
 /**
  * @private
  */
-br.formatting.DateFormatter.prototype.formatDate = function(oDate, sDateFormat, mAttributes) {
+DateFormatter.prototype.formatDate = function(oDate, sDateFormat, mAttributes) {
 	var oTranslator = require("br/I18n").getTranslator();
 	if(mAttributes && mAttributes.adjustForTimezone)
 	{
@@ -84,7 +87,7 @@ br.formatting.DateFormatter.prototype.formatDate = function(oDate, sDateFormat, 
 /**
  * @private
  */
-br.formatting.DateFormatter.prototype._adjustDateForTimezone = function(oDate) {
+DateFormatter.prototype._adjustDateForTimezone = function(oDate) {
 	var oDateClone = new Date(oDate.getTime()),
 		d = new Date(),
 		timezoneOffsetInMinutes = -(d.getTimezoneOffset());
@@ -97,6 +100,8 @@ br.formatting.DateFormatter.prototype._adjustDateForTimezone = function(oDate) {
 /**
  * @private
  */
-br.formatting.DateFormatter.prototype.toString = function() {
+DateFormatter.prototype.toString = function() {
 	return "br.formatting.DateFormatter";
 };
+
+module.exports = DateFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/DecimalFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/DecimalFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/DecimalFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+
 /**
  * @class
  * @alias module:br/formatting/DecimalFormatter
@@ -19,10 +23,9 @@
  * <p/>
  * <code>br.formatting.DecimalFormatter.format(3.14159, {dp:3})</code>
  */
-br.formatting.DecimalFormatter = function() {
-};
+function DecimalFormatter() {}
 
-br.Core.implement(br.formatting.DecimalFormatter, br.formatting.Formatter);
+topiarist.implement(DecimalFormatter, Formatter);
 
 /**
  * Formats the value to the specified number of decimal places.
@@ -46,13 +49,15 @@ br.Core.implement(br.formatting.DecimalFormatter, br.formatting.Formatter);
  * @return  the number, formatted to the specified precision.
  * @type  String
  */
-br.formatting.DecimalFormatter.prototype.format = function(vValue, mAttributes) {
-	return br.util.Number.isNumber(vValue) ? br.util.Number.toFixed(vValue, mAttributes["dp"]) : vValue;
+DecimalFormatter.prototype.format = function(vValue, mAttributes) {
+	return NumberUtil.isNumber(vValue) ? NumberUtil.toFixed(vValue, mAttributes["dp"]) : vValue;
 };
 
 /**
  * @private
  */
-br.formatting.DecimalFormatter.prototype.toString = function() {
+DecimalFormatter.prototype.toString = function() {
 	return "br.formatting.DecimalFormatter";
 };
+
+module.exports = DecimalFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/Formatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/Formatter.js
@@ -28,4 +28,4 @@ Formatter.prototype.format = function(vValue, mAttributes) {
 	throw new Errors.UnimplementedInterfaceError("Formatter.format() has not been implemented.");
 };
 
-br.formatting.Formatter = Formatter;
+module.exports = Formatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/KeyValueFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/KeyValueFormatter.js
@@ -2,6 +2,9 @@
  * @module br/formatting/KeyValueFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+
 /**
  * @class
  * @alias module:br/formatting/KeyValueFormatter
@@ -14,10 +17,9 @@
  * The <code>mAttributes</code> argument should have the map holding the mappings in it's
  * <code>map</code> key.
  */
-br.formatting.KeyValueFormatter = function() {
-};
+function KeyValueFormatter() {}
 
-br.Core.implement(br.formatting.KeyValueFormatter, br.formatting.Formatter);
+topiarist.implement(KeyValueFormatter, Formatter);
 
 /**
  * Substitutes a value with a mapped value if the a mapped value exists otherwise it returns the
@@ -27,7 +29,7 @@ br.Core.implement(br.formatting.KeyValueFormatter, br.formatting.Formatter);
  * @param {Map} mAttributes the object which holds a map of key-value pairs in its "map" element.
  * @return  the found value for the passed key or the the key if the value was not found.
  */
-br.formatting.KeyValueFormatter.prototype.format = function(vValue, mAttributes) {
+KeyValueFormatter.prototype.format = function(vValue, mAttributes) {
 	var mKeyValues = mAttributes.map;
 	return mKeyValues[vValue] || vValue;
 };
@@ -35,6 +37,8 @@ br.formatting.KeyValueFormatter.prototype.format = function(vValue, mAttributes)
 /**
  * @private
  */
-br.formatting.KeyValueFormatter.prototype.toString = function() {
+KeyValueFormatter.prototype.toString = function() {
 	return "br.formatting.KeyValueFormatter";
 };
+
+module.exports = KeyValueFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LeadingZeroFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LeadingZeroFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/LeadingZeroFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+
 /**
  * @class
  * @alias module:br/formatting/LeadingZeroFormatter
@@ -15,10 +19,9 @@
  * <p/>
  * <code>br.formatting.LeadingZeroFormatter.format(89, {length:4})</code>
  */
-br.formatting.LeadingZeroFormatter = function() {
-};
+function LeadingZeroFormatter() {}
 
-br.Core.implement(br.formatting.LeadingZeroFormatter, br.formatting.Formatter);
+topiarist.implement(LeadingZeroFormatter, Formatter);
 
 /**
  * Pads the integer part of a number with as many leading zeros needed to reach the specified size.
@@ -41,13 +44,15 @@ br.Core.implement(br.formatting.LeadingZeroFormatter, br.formatting.Formatter);
  * @return  the number, padded to the required length with leading zeros.
  * @type  String
  */
-br.formatting.LeadingZeroFormatter.prototype.format = function(vValue, mAttributes){
-	return br.util.Number.pad(vValue, mAttributes["length"]);
-}
+LeadingZeroFormatter.prototype.format = function(vValue, mAttributes){
+	return NumberUtil.pad(vValue, mAttributes.length);
+};
 
 /**
  * @private
  */
-br.formatting.LeadingZeroFormatter.prototype.toString = function() {
+LeadingZeroFormatter.prototype.toString = function() {
 	return "br.formatting.LeadingZeroFormatter";
 };
+
+module.exports = LeadingZeroFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedAmountFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedAmountFormatter.js
@@ -2,6 +2,9 @@
  * @module br/formatting/LocalisedAmountFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+
 /**
  * @class
  * @alias module:br/formatting/LocalisedAmountFormatter
@@ -20,12 +23,9 @@
  * <code>br.formatting.LocalisedAmountFormatter.format(1234567890, {})</code>
  * <code>br.formatting.LocalisedAmountFormatter.format(1234567890, {dp: 4})</code>
  */
-br.formatting.LocalisedAmountFormatter = function()
-{
+function LocalisedAmountFormatter() {}
 
-};
-
-br.Core.implement(br.formatting.LocalisedAmountFormatter, br.formatting.Formatter);
+topiarist.implement(LocalisedAmountFormatter, Formatter);
 
 /**
  * Formats a number into an localised string representation.
@@ -38,7 +38,7 @@ br.Core.implement(br.formatting.LocalisedAmountFormatter, br.formatting.Formatte
  * @return  the tokenized amount.
  * @type  String
  */
-br.formatting.LocalisedAmountFormatter.prototype.format = function(vValue, mAttributes) {
+LocalisedAmountFormatter.prototype.format = function(vValue, mAttributes) {
 
 	//the field may want to display a message like "please enter " so
 	if (typeof vValue == "string") {
@@ -66,6 +66,8 @@ br.formatting.LocalisedAmountFormatter.prototype.format = function(vValue, mAttr
 /**
  * @private
  */
-br.formatting.LocalisedAmountFormatter.prototype.toString = function() {
+LocalisedAmountFormatter.prototype.toString = function() {
 	return "br.formatting.LocalisedAmountFormatter";
 };
+
+module.exports = LocalisedAmountFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
@@ -1,0 +1,48 @@
+/**
+ * @module br/formatting/LocalisedDateFormatter
+ */
+
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
+
+/**
+ * @class
+ * @alias module:br/formatting/LocalisedDateFormatter
+ * @implements module:br/formatting/Formatter
+ *
+ * @classdesc
+ * Formats a date value by converting it from a specified input format to a new output format.
+ *
+ * <p><code>LocalisedDateFormatter</code> is typically used with Presenter, but can be invoked programmatically.
+ * It can make use of {@link http://momentjs.com/docs/#localized-formats|Moment.js localized formats} for input and output.</p>
+ *
+ * <code>new LocalisedDateFormatter().format('20150525', {inputFormat:'YYYYMMDD' outputFormat: 'LL'})</code>
+ *
+ * <p>It uses {@link http://momentjs.com/docs/#/i18n/|Moment.js locale configuration} to format localized dates.</p>
+ *
+ * See {@link module:br/parsing/LocalisedDateParser} for the complementary parser.
+ */
+function LocalisedDateFormatter() {}
+topiarist.implement(LocalisedDateFormatter, Formatter);
+
+/**
+ * Formats a date by converting it from a specified input format to a new output format.
+ *
+ * @param {string} date The input date
+ * @param {object} attributes Map of configuration options
+ * @param {string} attributes.inputFormat Format of the input date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} [attributes.outputFormat='L'] Format of the output date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} [attributes.locale] Locale override for the output
+ * @returns {string} The date, expressed in the output format
+ */
+LocalisedDateFormatter.prototype.format = function(date, attributes) {
+	var parseAttributes = {
+		inputFormats: [attributes.inputFormat],
+		outputFormat: attributes.outputFormat || 'L',
+		locale: attributes.locale
+	};
+	return LocalisedDateParser.prototype.parse(date, parseAttributes);
+};
+
+module.exports = LocalisedDateFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
@@ -4,7 +4,7 @@
 
 var topiarist = require('topiarist');
 var Formatter = require('br/formatting/Formatter');
-var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
+var LocalisedDateParsingUtil = require('br/parsing/LocalisedDateParsingUtil');
 
 /**
  * @class
@@ -12,7 +12,8 @@ var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
  * @implements module:br/formatting/Formatter
  *
  * @classdesc
- * Formats a date value by converting it from a specified input format to a new output format.
+ * Formats a date value by converting it from a specified input format to a new output format. This supersedes
+ * {@link br/formatting/DateFormatter}, which although it does provide localisation, is not completely reliable.
  *
  * <p><code>LocalisedDateFormatter</code> is typically used with Presenter, but can be invoked programmatically.
  * It can make use of {@link http://momentjs.com/docs/#localized-formats|Moment.js localized formats} for input and output.</p>
@@ -23,7 +24,9 @@ var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
  *
  * See {@link module:br/parsing/LocalisedDateParser} for the complementary parser.
  */
-function LocalisedDateFormatter() {}
+function LocalisedDateFormatter() {
+	this.localisedDateParsingUtil = new LocalisedDateParsingUtil();
+}
 topiarist.implement(LocalisedDateFormatter, Formatter);
 
 /**
@@ -33,16 +36,14 @@ topiarist.implement(LocalisedDateFormatter, Formatter);
  * @param {object} attributes Map of configuration options
  * @param {string} attributes.inputFormat Format of the input date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
  * @param {string} [attributes.outputFormat='L'] Format of the output date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
- * @param {string} [attributes.locale] Locale override for the output
+ * @param {string} [attributes.inputLocale] Locale override for the input
+ * @param {string} [attributes.outputLocale] Locale override for the output
  * @returns {string} The date, expressed in the output format
  */
 LocalisedDateFormatter.prototype.format = function(date, attributes) {
-	var parseAttributes = {
-		inputFormats: [attributes.inputFormat],
-		outputFormat: attributes.outputFormat || 'L',
-		locale: attributes.locale
-	};
-	return LocalisedDateParser.prototype.parse(date, parseAttributes);
+	attributes.inputFormats = [attributes.inputFormat];
+	attributes.outputFormat = attributes.outputFormat || 'L';
+	return this.localisedDateParsingUtil.parse(date, attributes);
 };
 
 module.exports = LocalisedDateFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LowerCaseFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LowerCaseFormatter.js
@@ -2,6 +2,9 @@
  * @module br/formatting/LowerCaseFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+
 /**
  * @class
  * @alias module:br/formatting/LowerCaseFormatter
@@ -15,10 +18,9 @@
  *
  * <pre>br.formatting.LowerCaseFormatter.format("Hello, World!", {})</pre>
  */
-br.formatting.LowerCaseFormatter = function() {
-};
+function LowerCaseFormatter() {}
 
-br.Core.implement(br.formatting.LowerCaseFormatter, br.formatting.Formatter);
+topiarist.implement(LowerCaseFormatter, Formatter);
 
 /**
  * Converts a string to lower case.
@@ -28,13 +30,15 @@ br.Core.implement(br.formatting.LowerCaseFormatter, br.formatting.Formatter);
  * @return  the string, converted to lower case.
  * @type  String
  */
-br.formatting.LowerCaseFormatter.prototype.format = function(vValue, mAttributes) {
+LowerCaseFormatter.prototype.format = function(vValue, mAttributes) {
 	return typeof(vValue) == "string" ? vValue.toLowerCase() : vValue
 };
 
 /**
  * @private
  */
-br.formatting.LowerCaseFormatter.prototype.toString = function() {
+LowerCaseFormatter.prototype.toString = function() {
 	return "br.formatting.LowerCaseFormatter";
 };
+
+module.exports = LowerCaseFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/NullValueFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/NullValueFormatter.js
@@ -2,6 +2,9 @@
  * @module br/formatting/NullValueFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+
 /**
  * @class
  * @alias module:br/formatting/NullValueFormatter
@@ -15,12 +18,11 @@
  *
  * <pre>br.formatting.NullValueFormatter.format("", {nullValue:"N/A"})</pre>
  */
-br.formatting.NullValueFormatter = function()
-{
+function NullValueFormatter() {
 	this.m_sNullValueDefault = "\u00a0";
-};
+}
 
-br.Core.implement(br.formatting.NullValueFormatter, br.formatting.Formatter);
+topiarist.implement(NullValueFormatter, Formatter);
 
 /**
  * Substitutes replacement text when the string is void (null, undefined, or the empty string).
@@ -43,13 +45,15 @@ br.Core.implement(br.formatting.NullValueFormatter, br.formatting.Formatter);
  * @return  the replacement string in the case of a void, otherwise the unchanged string.
  * @type  String
  */
-br.formatting.NullValueFormatter.prototype.format = function(vValue, mAttributes) {
+NullValueFormatter.prototype.format = function(vValue, mAttributes) {
 	return (vValue == undefined || vValue == null ||  vValue == "") ? mAttributes["nullValue"] == null ? this.m_sNullValueDefault : mAttributes["nullValue"] : vValue;
 };
 
 /**
  * @private
  */
-br.formatting.NullValueFormatter.prototype.toString = function() {
+NullValueFormatter.prototype.toString = function() {
 	return "br.formatting.NullValueFormatter";
 };
+
+module.exports = NullValueFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/PercentFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/PercentFormatter.js
@@ -2,6 +2,11 @@
  * @module br/formatting/PercentFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+var RoundingFormatter = require('br/formatting/RoundingFormatter');
+
 /**
  * @class
  * @alias module:br/formatting/PercentFormatter
@@ -15,11 +20,11 @@
  *
  * <pre>br.formatting.PercentFormatter.format(0.618, {dp:1})</pre>
  */
-br.formatting.PercentFormatter = function() {
-	this.roundingFormatter = new br.formatting.RoundingFormatter();
-};
+function PercentFormatter() {
+	this.roundingFormatter = new RoundingFormatter();
+}
 
-br.Core.implement(br.formatting.PercentFormatter, br.formatting.Formatter);
+topiarist.implement(PercentFormatter, Formatter);
 
 /**
  * Converts a decimal number to a percentage.
@@ -29,8 +34,8 @@ br.Core.implement(br.formatting.PercentFormatter, br.formatting.Formatter);
  * @return  the number specified as a percentage.
  * @type  String
  */
-br.formatting.PercentFormatter.prototype.format = function(vValue, mAttributes) {
-	if (br.util.Number.isNumber(vValue)) {
+PercentFormatter.prototype.format = function(vValue, mAttributes) {
+	if (NumberUtil.isNumber(vValue)) {
 		vValue = this.roundingFormatter.format(vValue * 100, mAttributes) + "%";
 	}
 	return vValue;
@@ -39,6 +44,8 @@ br.formatting.PercentFormatter.prototype.format = function(vValue, mAttributes) 
 /**
  * @private
  */
-br.formatting.PercentFormatter.prototype.toString = function() {
+PercentFormatter.prototype.toString = function() {
 	return "br.formatting.PercentFormatter";
 };
+
+module.exports = PercentFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/RegExpFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/RegExpFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/RegExpFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var RegExpUtil = require('br/util/RegExp');
+
 /**
  * @class
  * @alias module:br/formatting/RegExpFormatter
@@ -18,12 +22,11 @@
  * br.formatting.RegExpFormatter.format("Buy.USD", { match:"(\\.", replace:" " })
  * </pre>
  */
-br.formatting.RegExpFormatter = function()
-{
+function RegExpFormatter() {
 	this.m_oRegExps = {};
-};
+}
 
-br.Core.implement(br.formatting.RegExpFormatter, br.formatting.Formatter);
+topiarist.implement(RegExpFormatter, Formatter);
 
 /**
  * Transforms a string using a standard JavaScript regular expression.
@@ -51,7 +54,7 @@ br.Core.implement(br.formatting.RegExpFormatter, br.formatting.Formatter);
  * @return  the string, converted by the regular expression.
  * @type  String
  */
-br.formatting.RegExpFormatter.prototype.format = function(vValue, mAttributes) {
+RegExpFormatter.prototype.format = function(vValue, mAttributes) {
 	if (typeof(vValue) == "string") {
 		var oSearch = this.getRegExp(mAttributes["match"], mAttributes["flags"]);
 		var sReplace = mAttributes["replace"] != null ? mAttributes["replace"] : "$&";
@@ -63,11 +66,11 @@ br.formatting.RegExpFormatter.prototype.format = function(vValue, mAttributes) {
 /**
  * @private
  */
-br.formatting.RegExpFormatter.prototype.getRegExp = function(sMatch, sFlags) {
+RegExpFormatter.prototype.getRegExp = function(sMatch, sFlags) {
 	if (this.m_oRegExps[sMatch] == null) {
 		this.m_oRegExps[sMatch] = {};
 		if (this.m_oRegExps[sMatch][sFlags] == null) {
-			this.m_oRegExps[sMatch][sFlags] = new RegExp(br.util.RegExp.escape(sMatch), sFlags);
+			this.m_oRegExps[sMatch][sFlags] = new RegExp(RegExpUtil.escape(sMatch), sFlags);
 		}
 	}
 	return this.m_oRegExps[sMatch][sFlags];
@@ -76,6 +79,8 @@ br.formatting.RegExpFormatter.prototype.getRegExp = function(sMatch, sFlags) {
 /**
  * @private
  */
-br.formatting.RegExpFormatter.prototype.toString = function() {
+RegExpFormatter.prototype.toString = function() {
 	return "br.formatting.RegExpFormatter";
 };
+
+module.exports = RegExpFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/RoundingFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/RoundingFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/RoundingFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+
 /**
  * @class
  * @alias module:br/formatting/RoundingFormatter
@@ -15,10 +19,9 @@
  *
  * <pre>br.formatting.RoundingFormatter.format(3.14159, {dp:3})</pre>
  */
-br.formatting.RoundingFormatter = function() {
-};
+function RoundingFormatter() {}
 
-br.Core.implement(br.formatting.RoundingFormatter, br.formatting.Formatter);
+topiarist.implement(RoundingFormatter, Formatter);
 
 /**
  * Formats the number to the specified precision.
@@ -43,11 +46,11 @@ br.Core.implement(br.formatting.RoundingFormatter, br.formatting.Formatter);
  * @return  the number, formatted to the specified precision.
  * @type  String
  */
-br.formatting.RoundingFormatter.prototype.format = function(vValue, mAttributes) {
-	if (br.util.Number.isNumber(vValue)) {
-		vValue = br.util.Number.toPrecision(vValue, mAttributes["sf"]);
-		vValue = br.util.Number.toFixed(vValue, mAttributes["dp"]);
-		vValue = br.util.Number.toRounded(vValue, mAttributes["rounding"]);
+RoundingFormatter.prototype.format = function(vValue, mAttributes) {
+	if (NumberUtil.isNumber(vValue)) {
+		vValue = NumberUtil.toPrecision(vValue, mAttributes["sf"]);
+		vValue = NumberUtil.toFixed(vValue, mAttributes["dp"]);
+		vValue = NumberUtil.toRounded(vValue, mAttributes["rounding"]);
 	}
 	return vValue;
 };
@@ -55,6 +58,8 @@ br.formatting.RoundingFormatter.prototype.format = function(vValue, mAttributes)
 /**
  * @private
  */
-br.formatting.RoundingFormatter.prototype.toString = function() {
+RoundingFormatter.prototype.toString = function() {
 	return "br.formatting.RoundingFormatter";
 };
+
+module.exports = RoundingFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/SignificantFiguresFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/SignificantFiguresFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/SignificantFiguresFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+
 /**
  * @class
  * @alias module:br/formatting/SignificantFiguresFormatter
@@ -15,10 +19,9 @@
  *
  * <pre>br.formatting.SignificantFiguresFormatter.format(3.14159, {sf:4})</pre>
  */
-br.formatting.SignificantFiguresFormatter = function() {
-};
+function SignificantFiguresFormatter() {}
 
-br.Core.implement(br.formatting.SignificantFiguresFormatter, br.formatting.Formatter);
+topiarist.implement(SignificantFiguresFormatter, Formatter);
 
 /**
  * Formats a number to the specified number of significant figures.
@@ -41,13 +44,15 @@ br.Core.implement(br.formatting.SignificantFiguresFormatter, br.formatting.Forma
  * @return  the number, formatted to the specified precision.
  * @type  String
  */
-br.formatting.SignificantFiguresFormatter.prototype.format = function(vValue, mAttributes) {
-	return br.util.Number.isNumber(vValue) ? String(br.util.Number.toPrecision(vValue, mAttributes["sf"])) : vValue;
+SignificantFiguresFormatter.prototype.format = function(vValue, mAttributes) {
+	return NumberUtil.isNumber(vValue) ? String(NumberUtil.toPrecision(vValue, mAttributes["sf"])) : vValue;
 };
 
 /**
  * @private
  */
-br.formatting.SignificantFiguresFormatter.prototype.toString = function() {
+SignificantFiguresFormatter.prototype.toString = function() {
 	return "br.formatting.SignificantFiguresFormatter";
 };
+
+module.exports = SignificantFiguresFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/ThousandsFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/ThousandsFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/ThousandsFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NullValueFormatter = require('br/formatting/NullValueFormatter');
+
 /**
  * @class
  * @alias module:br/formatting/ThousandsFormatter
@@ -20,11 +24,11 @@
  *   <li><code>separator</code> - the character to use as a thousands separator</li>
  * </ul>
  */
-br.formatting.ThousandsFormatter = function() {
-	this.nullValueFormatter = new br.formatting.NullValueFormatter();
-};
+function ThousandsFormatter() {
+	this.nullValueFormatter = new NullValueFormatter();
+}
 
-br.Core.implement(br.formatting.ThousandsFormatter, br.formatting.Formatter);
+topiarist.implement(ThousandsFormatter, Formatter);
 
 /**
  * Adds a separator character for each 'thousand' position in a number. eg 1000000 becomes 1,000,000
@@ -34,7 +38,7 @@ br.Core.implement(br.formatting.ThousandsFormatter, br.formatting.Formatter);
  * @return The formatted value
  * @type String
  */
-br.formatting.ThousandsFormatter.prototype.format = function(vValue, mAttributes) {
+ThousandsFormatter.prototype.format = function(vValue, mAttributes) {
 	vValue = vValue === 0 ? 0 : this.nullValueFormatter.format(vValue, mAttributes);
 	try
 	{
@@ -57,12 +61,12 @@ br.formatting.ThousandsFormatter.prototype.format = function(vValue, mAttributes
  * @return The number value or null if one cannot be found
  * @private
  */
-br.formatting.ThousandsFormatter.prototype._stripSuffix = function(sValue) {
+ThousandsFormatter.prototype._stripSuffix = function(sValue) {
 	var sMatch = sValue.match(/(\d+(,?\d)?)+(\.\d+)?/);
 	return sMatch != null ? sMatch[0] : sValue;
 };
 
-br.formatting.ThousandsFormatter.prototype._stripComma = function(sValue) {
+ThousandsFormatter.prototype._stripComma = function(sValue) {
 	return sValue.replace(/,/g, "");
 };
 
@@ -72,6 +76,8 @@ br.formatting.ThousandsFormatter.prototype._stripComma = function(sValue) {
  * @return  The string representation
  * @type String
  */
-br.formatting.ThousandsFormatter.prototype.toString = function() {
+ThousandsFormatter.prototype.toString = function() {
 	return "br.formatting.ThousandsFormatter";
 };
+
+module.exports = ThousandsFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/TrimFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/TrimFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/TrimFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var RegExpFormatter = require('br/formatting/RegExpFormatter');
+
 /**
  * @class
  * @alias module:br/formatting/TrimFormatter
@@ -10,11 +14,11 @@
  * @classdesc
  * Trims whitespace from boths ends of the string.
  */
-br.formatting.TrimFormatter = function() {
-	this.regExpFormatter = new br.formatting.RegExpFormatter();
-};
+function TrimFormatter() {
+	this.regExpFormatter = new RegExpFormatter();
+}
 
-br.Core.implement(br.formatting.TrimFormatter, br.formatting.Formatter);
+topiarist.implement(TrimFormatter, Formatter);
 
 /**
  * Trims whitespace from boths ends of the string.
@@ -29,7 +33,7 @@ br.Core.implement(br.formatting.TrimFormatter, br.formatting.Formatter);
  * @return  the trimmed string.
  * @type  String
  */
-br.formatting.TrimFormatter.prototype.format = function(vValue, mAttributes) {
+TrimFormatter.prototype.format = function(vValue, mAttributes) {
 	var mRegExpAttributes = {
 		match: "(^(\\s|\\u00A0)+|(\\s|\\u00A0)+$)",
 		flags: "g",
@@ -41,6 +45,8 @@ br.formatting.TrimFormatter.prototype.format = function(vValue, mAttributes) {
 /**
  * @private
  */
-br.formatting.TrimFormatter.prototype.toString = function() {
+TrimFormatter.prototype.toString = function() {
 	return "br.formatting.TrimFormatter";
 };
+
+module.exports = TrimFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/TruncateDecimalFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/TruncateDecimalFormatter.js
@@ -2,6 +2,10 @@
  * @module br/formatting/TruncateDecimalFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+var NumberUtil = require('br/util/Number');
+
 /**
  * @class
  * @alias module:br/formatting/TruncateDecimalFormatter
@@ -15,10 +19,9 @@
  *
  * <pre>br.formatting.TruncateDecimalFormatter.format(3.14159, {dp:3})</pre>
  */
-br.formatting.TruncateDecimalFormatter = function() {
-};
+function TruncateDecimalFormatter() {}
 
-br.Core.implement(br.formatting.TruncateDecimalFormatter, br.formatting.Formatter);
+topiarist.implement(TruncateDecimalFormatter, Formatter);
 
 /**
  * Truncates the value to the specified number of decimal places.  If the value has already fewer
@@ -42,11 +45,11 @@ br.Core.implement(br.formatting.TruncateDecimalFormatter, br.formatting.Formatte
  * @return  the number formatted to the specified precision.
  * @type  String
  */
-br.formatting.TruncateDecimalFormatter.prototype.format = function(vValue, mAttributes) {
-	if (br.util.Number.isNumber(vValue)) {
+TruncateDecimalFormatter.prototype.format = function(vValue, mAttributes) {
+	if (NumberUtil.isNumber(vValue)) {
 		var sValue = String(vValue);
 		var sUnFormattedValue = this._removeExponent(sValue);
-		var sFormattedValue = br.util.Number.toFixed(vValue, mAttributes["dp"]);
+		var sFormattedValue = NumberUtil.toFixed(vValue, mAttributes["dp"]);
 		vValue = this._getShorter(sFormattedValue, sUnFormattedValue);
 	}
 	return vValue;
@@ -55,20 +58,22 @@ br.formatting.TruncateDecimalFormatter.prototype.format = function(vValue, mAttr
 /**
  * @private
  */
-br.formatting.TruncateDecimalFormatter.prototype._removeExponent = function(s) {
+TruncateDecimalFormatter.prototype._removeExponent = function(s) {
 	return s.indexOf("e") >= 0 ? String(Number(s)) : s;
 };
 
 /**
  * @private
  */
-br.formatting.TruncateDecimalFormatter.prototype._getShorter = function(s1, s2) {
+TruncateDecimalFormatter.prototype._getShorter = function(s1, s2) {
 	return s1.length < s2.length ? s1 : s2;
 };
 
 /**
  * @private
  */
-br.formatting.TruncateDecimalFormatter.prototype.toString = function() {
+TruncateDecimalFormatter.prototype.toString = function() {
 	return "br.formatting.TruncateDecimalFormatter";
 };
+
+module.exports = TruncateDecimalFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/UpperCaseFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/UpperCaseFormatter.js
@@ -2,6 +2,9 @@
  * @module br/formatting/UpperCaseFormatter
  */
 
+var topiarist = require('topiarist');
+var Formatter = require('br/formatting/Formatter');
+
 /**
  * @class
  * @alias module:br/formatting/UpperCaseFormatter
@@ -15,10 +18,9 @@
  *
  * <pre>br.formatting.UpperCaseFormatter.format("Hello, World!", {})</pre>
  */
-br.formatting.UpperCaseFormatter = function() {
-};
+function UpperCaseFormatter() {}
 
-br.Core.implement(br.formatting.UpperCaseFormatter, br.formatting.Formatter);
+topiarist.implement(UpperCaseFormatter, Formatter);
 
 /**
  * Converts a string to lower case.
@@ -28,13 +30,15 @@ br.Core.implement(br.formatting.UpperCaseFormatter, br.formatting.Formatter);
  * @return  the string, converted to upper case.
  * @type  String
  */
-br.formatting.UpperCaseFormatter.prototype.format = function(vValue, mAttributes) {
+UpperCaseFormatter.prototype.format = function(vValue, mAttributes) {
 	return typeof(vValue) == "string" ? vValue.toUpperCase() : vValue
 };
 
 /**
  * @private
  */
-br.formatting.UpperCaseFormatter.prototype.toString = function() {
+UpperCaseFormatter.prototype.toString = function() {
 	return "br.formatting.UpperCaseFormatter";
 };
+
+module.exports = UpperCaseFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
@@ -3,7 +3,6 @@
 	require('jsunitextensions');
 
 	var LocalisedDateFormatter = require('br/formatting/LocalisedDateFormatter');
-	var moment = require('momentjs');
 	var formatter;
 
 	var testCase = {
@@ -32,21 +31,20 @@
 		},
 
 		'test english localised format': function() {
-			moment.lang('en');
 			var result = formatter.format('20150125', {
 				inputFormat: 'YYYYMMDD',
-				outputFormat: 'L'
+				outputFormat: 'L',
+				outputLocale: 'en'
 			});
 
 			assertEquals('01/25/2015', result);
 		},
 
-		'test formatting to a locale other than the global one': function() {
-			moment.lang('en');
+		'test format to UK localised date format': function() {
 			var result = formatter.format('20150125', {
 				inputFormat: 'YYYYMMDD',
 				outputFormat: 'L',
-				locale: 'en-gb'
+				outputLocale: 'en-gb'
 			});
 
 			assertEquals('25/01/2015', result);

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
@@ -1,0 +1,58 @@
+(function() {
+
+	require('jsunitextensions');
+
+	var LocalisedDateFormatter = require('br/formatting/LocalisedDateFormatter');
+	var moment = require('momentjs');
+	var formatter;
+
+	var testCase = {
+		setUp: function() {
+			formatter = new LocalisedDateFormatter();
+		},
+
+		tearDown: function() {},
+
+		'test formatting YYYYMMDD to DDMMYYYY': function() {
+			var result = formatter.format('20150125', {
+				inputFormat: 'YYYYMMDD',
+				outputFormat: 'DDMMYYYY'
+			});
+
+			assertEquals('25012015', result);
+		},
+
+		'test formatting failure': function() {
+			var result = formatter.format('', {
+				inputFormat: 'YYYYMMDD',
+				outputFormat: 'DDMMYYYY'
+			});
+
+			assertUndefined(result);
+		},
+
+		'test english localised format': function() {
+			moment.lang('en');
+			var result = formatter.format('20150125', {
+				inputFormat: 'YYYYMMDD',
+				outputFormat: 'L'
+			});
+
+			assertEquals('01/25/2015', result);
+		},
+
+		'test formatting to a locale other than the global one': function() {
+			moment.lang('en');
+			var result = formatter.format('20150125', {
+				inputFormat: 'YYYYMMDD',
+				outputFormat: 'L',
+				locale: 'en-gb'
+			});
+
+			assertEquals('25/01/2015', result);
+		}
+
+	};
+
+	return new TestCase('LocalisedDateParserTest', testCase);
+}());

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/ThousandsFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/ThousandsFormatterTest.js
@@ -1,6 +1,6 @@
 (function() {
 	ThousandsFormatterTest = TestCase("ThousandsFormatterTest");
-
+	require('jsunitextensions');
 	var ThousandsFormatter = require('br/presenter/formatter/ThousandsFormatter');
 
 	ThousandsFormatterTest.prototype.setUp = function()
@@ -14,7 +14,6 @@
 	ThousandsFormatterTest.prototype.tearDown = function()
 	{
 		this.subrealm.uninstall();
-		globalizeSourceModules();
 	};
 
 	ThousandsFormatterTest.prototype.test_nonDecimals = function()
@@ -102,7 +101,7 @@
 			}, 'locale'));
 		});
 
-		this.oFormatter = new br.presenter.formatter.ThousandsFormatter();
+		this.oFormatter = new ThousandsFormatter();
 
 		assertEquals("1,000", this.oFormatter.format("1.000", {}));
 		assertEquals("10,00", this.oFormatter.format("10.00", {}));

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
@@ -9,6 +9,7 @@ var RegExpUtil = require('br/util/RegExp');
 var DateParsingUtil = require('br/parsing/DateParsingUtil');
 
 /**
+ * @deprecated The functionality provided by this parser can be achieved more reliably with {@link module:br/parsing/LocalisedDateParser}
  * @class
  * @alias module:br/parsing/DateParser
  * @implements module:br/parsing/Parser

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParser.js
@@ -6,6 +6,7 @@ var topiarist = require('topiarist');
 var Parser = require('br/parsing/Parser');
 var DateFormatter = require('br/formatting/DateFormatter');
 var RegExpUtil = require('br/util/RegExp');
+var DateParsingUtil = require('br/parsing/DateParsingUtil');
 
 /**
  * @class
@@ -64,48 +65,7 @@ DateParser.prototype.parse = function(vValue, mAttributes) {
 };
 
 DateParser.prototype.isSingleUseParser = function() {
-  return false;
-};
-
-/**
- * @static
- * @param {string|Date} vDate The date to parse
- * @param {string} sDateFormat The input format
- * @param {object} [mAttributes] A map of options
- * @param {boolean} [mAttributes.endOfUnit=false] Whether to parse ambiguous dates to the end of a month or year
- * @returns {Date}
- */
-DateParser.parseDate = function(vDate, sDateFormat, mAttributes) {
-	if (!vDate)
-	{
-		return null;
-	}
-	if (vDate instanceof Date)
-	{
-		sDateFormat = "javascript";
-	}
-	else if (!sDateFormat)
-	{
-		sDateFormat = "DD-MM-YYYY HH:mm:ss";
-	}
-
-	switch (sDateFormat) {
-		case "java":
-			var oDate = new Date();
-			oDate.setTime(Number(vDate));
-			return oDate;
-		case "javascript":
-			return vDate;
-		case "U":
-			return moment(vDate*1000).toDate();
-		default:
-			var oMoment = moment(String(vDate), sDateFormat);
-			if (mAttributes && mAttributes.endOfUnit === true && sDateFormat.toLowerCase().indexOf('d') === -1) {
-				oMoment.endOf(sDateFormat === 'YYYY' ? 'year' : 'month');
-			}
-			var sValidationString = oMoment.format(sDateFormat);
-			return (sValidationString.toLowerCase() == String(vDate).toLowerCase()) ? oMoment.toDate() : null;
-	}
+	return false;
 };
 
 /**
@@ -113,7 +73,7 @@ DateParser.parseDate = function(vDate, sDateFormat, mAttributes) {
  */
 DateParser.prototype._matchDate = function(vDate, pInputFormats, sOutputFormat, mAttributes) {
 	for (var i = 0, n = pInputFormats.length; i < n; ++i) {
-		var oDate = br.parsing.DateParser.parseDate(vDate, pInputFormats[i], mAttributes);
+		var oDate = DateParsingUtil.parse(vDate, pInputFormats[i], mAttributes);
 		if (oDate) {
 			return this.m_oDateFormatter.formatDate(oDate, sOutputFormat);
 		}

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParsingUtil.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/DateParsingUtil.js
@@ -1,0 +1,47 @@
+/**
+ * @module br/parsing/DateParsingUtil
+ */
+
+var moment = require('momentjs');
+
+module.exports = {
+
+	/**
+	 * @static
+	 * @param {string|Date} vDate The date to parse
+	 * @param {string} sDateFormat The input format
+	 * @param {object} [mAttributes] A map of options
+	 * @param {boolean} [mAttributes.endOfUnit=false] Whether to parse ambiguous dates to the end of a month or year
+	 * @returns {Date}
+	 */
+	parse: function(vDate, sDateFormat, mAttributes) {
+		if (!vDate){
+			return null;
+		}
+		
+		if (vDate instanceof Date) {
+			sDateFormat = "javascript";
+		} else if (!sDateFormat) {
+			sDateFormat = "DD-MM-YYYY HH:mm:ss";
+		}
+
+		switch (sDateFormat) {
+			case "java":
+				var oDate = new Date();
+				oDate.setTime(Number(vDate));
+				return oDate;
+			case "javascript":
+				return vDate;
+			case "U":
+				return moment(vDate*1000).toDate();
+			default:
+				var oMoment = moment(String(vDate), sDateFormat);
+				if (mAttributes && mAttributes.endOfUnit === true && sDateFormat.toLowerCase().indexOf('d') === -1) {
+					oMoment.endOf(sDateFormat === 'YYYY' ? 'year' : 'month');
+				}
+				var sValidationString = oMoment.format(sDateFormat);
+				return (sValidationString.toLowerCase() == String(vDate).toLowerCase()) ? oMoment.toDate() : null;
+		}
+	}
+	
+};

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
@@ -20,8 +20,7 @@ var Parser = require('br/parsing/Parser');
  * 
  * See {@link module:br/formatting/AmountFormatter} for the complementary formatter.
  */
-LocalisedAmountParser = function() {
-}
+function LocalisedAmountParser() {}
 
 topiarist.implement(LocalisedAmountParser, Parser);
 

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParser.js
@@ -1,0 +1,79 @@
+/**
+ * @module br/parsing/LocalisedDateParser
+ */
+
+var topiarist = require('topiarist');
+var Parser = require('br/parsing/Parser');
+var moment = require('momentjs');
+
+/**
+ * @class
+ * @alias module:br/parsing/LocalisedDateParser
+ * @implements module:br/parsing/Parser
+ * 
+ * @classdesc
+ * Matches a date string and converts it to a specified output format.
+ * 
+ * <p><code>LocalisedDateParser</code> is typically used with Presenter, but can be invoked programmatically.
+ * It can make use of {@link http://momentjs.com/docs/#localized-formats|Moment.js localized formats} for input and output.</p>
+ * 
+ * <code>new LocalisedDateParser().parse('09/08/2000', {inputFormats: ['MM/DD/YYYY'], outputFormat: 'LL'})</code>
+ *
+ * <p>It uses {@link http://momentjs.com/docs/#/i18n/|Moment.js locale configuration} to parse localized dates.</p>
+ * 
+ * See {@link module:br/formatting/LocalisedDateFormatter} for the complementary formatter.
+ */
+function LocalisedDateParser() {}
+topiarist.implement(LocalisedDateParser, Parser);
+
+/**
+ * Matches a date string and converts it to a specified output format.
+ *
+ * @param {string} date The date to parse
+ * @param {object} attributes Map of configuration options
+ * @param {string[]} attributes.inputFormats The possible input formats, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} attributes.outputFormat The output format, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} [attributes.locale] Locale override for the output
+ * @param {boolean} [attributes.endOfUnit=false] If true, parse ambiguous dates to the end of the month or year
+ * @returns {string} The date, expressed in the output format
+ */
+LocalisedDateParser.prototype.parse = function(date, attributes) {
+	var parsedDate;
+	var parseSuccessful = attributes.inputFormats.some(function(format) {
+		parsedDate = parse(date, format, attributes);
+		return parsedDate.isValid();
+	});
+
+	if (parseSuccessful) {
+		if (typeof attributes.locale !== 'undefined') {
+			parsedDate.lang(attributes.locale);
+		}
+		return parsedDate.format(attributes.outputFormat);
+	}
+};
+
+/**
+ */
+LocalisedDateParser.prototype.isSingleUseParser = function() {
+  return false;
+};
+
+/**
+ * @private
+ * @param {string} date The date to parse
+ * @param {string} format The input format
+ * @param {object} attributes Map of attributes
+ * @returns {object} A Moment.js object
+ */
+function parse(date, format, attributes) {
+	var parsedDate = moment(date, format);
+	var lowerCaseFormat = format.toLowerCase();
+
+	if (attributes.endOfUnit === true && lowerCaseFormat.indexOf('d') === -1) {
+		parsedDate.endOf(lowerCaseFormat.indexOf('m') === -1 ? 'year' : 'month');
+	}
+
+	return parsedDate;
+}
+
+module.exports = LocalisedDateParser;

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
@@ -1,0 +1,52 @@
+/**
+ * @module br/parsing/LocalisedDateParsingUtil
+ */
+
+var moment = require('momentjs');
+var LocaleService = require('service!br.locale-service');
+
+/**
+ * @class
+ * @alias module:br/parsing/LocalisedDateParsingUtil
+ * 
+ * @classdesc Utility class for parsing dates
+ */
+function LocalisedDateParsingUtil() {
+	this.locale = LocaleService.getLocale().replace('_', '-');
+}
+
+/**
+ * Matches a date string and converts it to a specified output format.
+ *
+ * @param {string} date The date to parse
+ * @param {object} attributes Map of configuration options
+ * @param {string[]} attributes.inputFormats The possible input formats, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} attributes.outputFormat The output format, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
+ * @param {string} [attributes.inputLocale] Locale override for the input
+ * @param {string} [attributes.outputLocale] Locale override for the output
+ * @param {boolean} [attributes.endOfUnit=false] If true, parse ambiguous dates to the end of the month or year
+ * @returns {string} The date, expressed in the output format
+ */
+LocalisedDateParsingUtil.prototype.parse = function(date, attributes) {
+	var inputLocale = attributes.inputLocale || this.locale;
+	var outputLocale = attributes.outputLocale || this.locale;
+	var parsedDate;
+
+	var parseSuccessful = attributes.inputFormats.some(function(format) {
+		var lowerCaseFormat = format.toLowerCase();
+		parsedDate = moment(date, format, inputLocale);
+
+		if (attributes.endOfUnit === true && lowerCaseFormat.indexOf('d') === -1) {
+			parsedDate.endOf(lowerCaseFormat.indexOf('m') === -1 ? 'year' : 'month');
+		}
+
+		return parsedDate.isValid();
+	});
+
+	if (parseSuccessful) {
+		parsedDate.lang(outputLocale);
+		return parsedDate.format(attributes.outputFormat);
+	}
+};
+
+module.exports = LocalisedDateParsingUtil;

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/ThousandsParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/ThousandsParser.js
@@ -24,8 +24,7 @@ var Parser = require('br/parsing/Parser');
  * 
  * See {@link module:br/formatting/ThousandsFormatter} for the complementary formatter.
  */
-ThousandsParser = function() {
-}
+function ThousandsParser() {}
 
 topiarist.implement(ThousandsParser, Parser);
 

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
@@ -1,0 +1,101 @@
+(function() {
+
+	require('jsunitextensions');
+
+	var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
+	var moment = require('momentjs');
+	var parser;
+
+	var testCase = {
+		setUp: function() {
+			parser = new LocalisedDateParser();
+		},
+
+		tearDown: function() {},
+
+		'test parser implements isSingleUseParser': function() {
+			assertFalse(parser.isSingleUseParser());
+		},
+
+		'test parsing YYYYMMDD to DDMMYYYY': function() {
+			var result = parser.parse('20150125', {
+				inputFormats: ['YYYYMMDD'],
+				outputFormat: 'DDMMYYYY'
+			});
+
+			assertEquals('25012015', result);
+		},
+
+		'test parsing failure': function() {
+			var result = parser.parse('', {
+				inputFormats: ['YYYYMMDD'],
+				outputFormat: 'DDMMYYYY'
+			});
+
+			assertUndefined(result);
+		},
+
+		'test parsing to US localised format': function() {
+			moment.lang('en');
+			var result = parser.parse('20150125', {
+				inputFormats: ['YYYYMMDD'],
+				outputFormat: 'L'
+			});
+
+			assertEquals('01/25/2015', result);
+		},
+
+		'test parsing to a locale other than the global one': function() {
+			moment.lang('en');
+			var result = parser.parse('20150125', {
+				inputFormats: ['YYYYMMDD'],
+				outputFormat: 'L',
+				locale: 'en-gb'
+			});
+
+			assertEquals('25/01/2015', result);
+		},
+
+		'test parsing with multiple input formats': function() {
+			var result = parser.parse('20150125', {
+				inputFormats: ['YYYY-MM-DD', 'YYYY/MM/DD', 'YYYY MM DD', 'YYYYMMDD'],
+				outputFormat: 'DDMMYYYY'
+			});
+
+			assertEquals('25012015', result);
+		},
+
+		'test parsing ambiguous date to end of year': function() {
+			var result = parser.parse('2015', {
+				inputFormats: ['YYYY'],
+				outputFormat: 'YYYYMMDD',
+				endOfUnit: true
+			});
+
+			assertEquals('20151231', result);
+		},
+
+		'test parsing ambiguous date to end of month': function() {
+			var result = parser.parse('012015', {
+				inputFormats: ['MMYYYY'],
+				outputFormat: 'YYYYMMDD',
+				endOfUnit: true
+			});
+
+			assertEquals('20150131', result);
+		},
+
+		'test parsing unambiguous date with endOfUnit flag set': function() {
+			var result = parser.parse('05012015', {
+				inputFormats: ['DDMMYYYY'],
+				outputFormat: 'YYYYMMDD',
+				endOfUnit: true
+			});
+
+			assertEquals('20150105', result);
+		}
+
+	};
+
+	return new TestCase('LocalisedDateParserTest', testCase);
+}());

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
@@ -3,7 +3,6 @@
 	require('jsunitextensions');
 
 	var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
-	var moment = require('momentjs');
 	var parser;
 
 	var testCase = {
@@ -36,24 +35,33 @@
 		},
 
 		'test parsing to US localised format': function() {
-			moment.lang('en');
 			var result = parser.parse('20150125', {
 				inputFormats: ['YYYYMMDD'],
-				outputFormat: 'L'
+				outputFormat: 'L',
+				outputLocale: 'en'
 			});
 
 			assertEquals('01/25/2015', result);
 		},
 
-		'test parsing to a locale other than the global one': function() {
-			moment.lang('en');
+		'test parsing to a UK localised format': function() {
 			var result = parser.parse('20150125', {
 				inputFormats: ['YYYYMMDD'],
 				outputFormat: 'L',
-				locale: 'en-gb'
+				outputLocale: 'en-gb'
 			});
 
 			assertEquals('25/01/2015', result);
+		},
+
+		'test parsing from a localised format': function() {
+			var result = parser.parse('25/01/2015', {
+				inputFormats: ['L'],
+				outputFormat: 'YYYYMMDD',
+				inputLocale: 'en-gb'
+			});
+
+			assertEquals('20150125', result);
 		},
 
 		'test parsing with multiple input formats': function() {

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/ThousandsParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/ThousandsParserTest.js
@@ -13,7 +13,6 @@
 	ThousandsParserTest.prototype.tearDown = function()
 	{
 		this.subrealm.uninstall();
-		globalizeSourceModules();
 	};
 
 	ThousandsParserTest.prototype.test_Int = function() {


### PR DESCRIPTION
These new classes serve to let Moment.js handle localisation of dates. The shortcomings of the existing DateParser and DateFormatter with regards to localisation (described in part [here](https://github.com/BladeRunnerJS/brjs/issues/1270) and [here](https://github.com/BladeRunnerJS/brjs/issues/1228)) cannot be easily addressed whilst maintaining backwards compatibility.

This PR should perhaps not be merged as is. Moment.js locale configuration should be performed somewhere. i.e.

    require('momentjs').lang(appLocale);

<!---
@huboard:{"order":1275.0,"milestone_order":1275,"custom_state":""}
-->
