### PR TITLE
Close underlying reader when closing XMLSiblingReader instances.

### DIFF
--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/xml/XMLContentPlugin.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/xml/XMLContentPlugin.java
@@ -1,5 +1,6 @@
 package org.bladerunnerjs.plugin.bundlers.xml;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,7 +78,7 @@ public class XMLContentPlugin extends AbstractContentPlugin
 			
 			return new CharResponseContent(brjs, result);
 		}
-		catch(XMLStreamException  e) {
+		catch(IOException | XMLStreamException  e) {
 			throw new ContentProcessingException(e, "Error while processing XML assets '" );
 		}
 	}

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/xml/XmlBundleWriter.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/xml/XmlBundleWriter.java
@@ -48,7 +48,7 @@ public class XmlBundleWriter
 		}
 	};
 	
-	public void writeBundle(List<Asset> xmlAssets, final Writer writer) throws ContentProcessingException, XMLStreamException {
+	public void writeBundle(List<Asset> xmlAssets, final Writer writer) throws ContentProcessingException, XMLStreamException, IOException {
 		
 		Map<String, List<XmlSiblingReader>> resourceReaders = null;
 		
@@ -70,12 +70,7 @@ public class XmlBundleWriter
 				{
 					for(XmlSiblingReader siblingReader : siblingReaders)
 					{
-						try {
-							siblingReader.close();
-						}
-						catch(XMLStreamException e) {
-							// do nothing: we want to close as many readers as possible
-						}
+						siblingReader.close();
 					}
 				}
 			}
@@ -83,7 +78,7 @@ public class XmlBundleWriter
 	}
 	
 	private void writeBundleInternal(final Map<String, List<XmlSiblingReader>> resourceReaders, final XMLStreamWriter writer) 
-			throws XMLStreamException, XmlSiblingReaderException, ContentProcessingException
+			throws XMLStreamException, XmlSiblingReaderException, ContentProcessingException, IOException
 	{
 		writer.setDefaultNamespace("http://schema.caplin.com/CaplinTrader/bundle");
 		writer.writeStartDocument();
@@ -131,8 +126,7 @@ public class XmlBundleWriter
 			
 			MemoizedFile document = xmlAsset.dir().file(xmlAsset.getAssetName());
 			try{
-				Reader bundlerFileReader = xmlAsset.getReader();
-				XmlSiblingReader siblingReader = new XmlSiblingReader(inputFactory.createXMLStreamReader(bundlerFileReader));
+				XmlSiblingReader siblingReader = new XmlSiblingReader(inputFactory, xmlAsset.getReader());
 				siblingReader.setAsset(xmlAsset);
 				
 				siblingReader.setXmlDocument(document);
@@ -381,7 +375,7 @@ public class XmlBundleWriter
 		return childReaders;
 	}
 
-	private void closeResourceReaders(final List<XmlSiblingReader> readers) throws XMLStreamException
+	private void closeResourceReaders(final List<XmlSiblingReader> readers) throws IOException
 	{
 		for (XmlSiblingReader reader : readers)
 		{


### PR DESCRIPTION
This check-in potentially fixes #446. Since we've never been able to replicate the problem in the first place (only @janhancic can), it's impossible to be sure though.

<!---
@huboard:{"order":543.5,"milestone_order":1281,"custom_state":""}
-->
