### PR TITLE
LocalisedDateParser fix

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
@@ -34,7 +34,7 @@ LocalisedDateParsingUtil.prototype.parse = function(date, attributes) {
 
 	var parseSuccessful = attributes.inputFormats.some(function(format) {
 		var lowerCaseFormat = format.toLowerCase();
-		parsedDate = moment(date, format, inputLocale);
+		parsedDate = moment(date, format, inputLocale, true);
 
 		if (attributes.endOfUnit === true && lowerCaseFormat.indexOf('d') === -1) {
 			parsedDate.endOf(lowerCaseFormat.indexOf('m') === -1 ? 'year' : 'month');

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
@@ -101,6 +101,14 @@
 			});
 
 			assertEquals('20150105', result);
+		},
+
+		'test parsing does not make loose matches': function() {
+			var result = parser.parse('18 Mar 2015', {
+				inputFormats: ['YYYY']
+			});
+
+			assertUndefined(result);
 		}
 
 	};


### PR DESCRIPTION
We should be using Moment's strict parse flag to avoid loose matches which can lead to unexpected results.

Without this change, the test example "18 Mar 2015" is parsed as "YYYY" to the year 18. Only exact matches are particularly useful.