### PR TITLE
fixing bad model paths for xml and html JSTD bundle aliases

### DIFF
--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
@@ -40,8 +40,8 @@ public class BundlerHandler
 		logicalBundlerHandlerPaths.put("bundle.js", "js/dev/combined/bundle.js");
 		logicalBundlerHandlerPaths.put("bundle.css", "css/common/bundle.css");
 		logicalBundlerHandlerPaths.put("bundle.i18n", "i18n/en_GB.js");
-		logicalBundlerHandlerPaths.put("bundle.xml", "bundle.xml");
-		logicalBundlerHandlerPaths.put("bundle.html", "bundle.html");
+		logicalBundlerHandlerPaths.put("bundle.xml", "xml/bundle.xml");
+		logicalBundlerHandlerPaths.put("bundle.html", "html/bundle.html");
 		
 		this.bundlableNode = bundlableNode;
 	}

--- a/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandlerTest.java
+++ b/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandlerTest.java
@@ -256,5 +256,22 @@ public class BundlerHandlerTest extends BundlerHandlerSpecTest
     				"// $£€" );
 	}
 	
+	@Test
+	public void allPossibleBundlePathAliasesAreValidModelRequests() throws Exception
+	{
+		whenJstdTests(aspectTestPack).runWithPaths( 
+				"bundles/js.bundle",
+				"bundles/css.bundle",
+				"bundles/i18n.bundle",
+				"bundles/en_i18n.bundle",
+				"bundles/xml.bundle",
+				"bundles/html.bundle",
+				"bundles/bundle.js",
+				"bundles/bundle.css",
+				"bundles/bundle.i18n",
+				"bundles/bundle.xml",
+				"bundles/bundle.html");
+		then(exceptions).verifyNoOutstandingExceptions();
+	}
 	
 }

--- a/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/specutility/BundlerHandlerSpecTest.java
+++ b/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/specutility/BundlerHandlerSpecTest.java
@@ -35,12 +35,14 @@ public class BundlerHandlerSpecTest extends SpecTest
 			this.testPack = testPack;
 		}
 
-		public void runWithPaths(String requestPath) throws Exception
+		public void runWithPaths(String... requestPaths) throws Exception
 		{
-			File bundleFile = testPack.file(requestPath);
-			String bundlePath = StringUtils.substringAfterLast(bundleFile.getAbsolutePath(), JsTestDriverBundleCreator.BUNDLES_DIR_NAME + File.separator);
-			bundlePath = StringUtils.replace(bundlePath, "\\", "/");
-			new BundlerHandler(testPack).createBundleFile(bundleFile, bundlePath, brjs.getAppVersionGenerator().getDevVersion());
+			for (String requestPath : requestPaths) {
+    			File bundleFile = testPack.file(requestPath);
+    			String bundlePath = StringUtils.substringAfterLast(bundleFile.getAbsolutePath(), JsTestDriverBundleCreator.BUNDLES_DIR_NAME + File.separator);
+    			bundlePath = StringUtils.replace(bundlePath, "\\", "/");
+    			new BundlerHandler(testPack).createBundleFile(bundleFile, bundlePath, brjs.getAppVersionGenerator().getDevVersion());
+			}
 		}
 	}
 


### PR DESCRIPTION
Using the correct paths that are supplied to the model when `bundle.xml` and `bundle.html` are used in JSTD conf files.