### PR TITLE
LocalisedDateParser fix #2

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedDateParsingUtil.js
@@ -36,7 +36,7 @@ LocalisedDateParsingUtil.prototype.parse = function(date, attributes) {
 		var lowerCaseFormat = format.toLowerCase();
 		parsedDate = moment(date, format, inputLocale, true);
 
-		if (attributes.endOfUnit === true && lowerCaseFormat.indexOf('d') === -1) {
+		if (attributes.endOfUnit === true && lowerCaseFormat.indexOf('d') === -1 && lowerCaseFormat.indexOf('l') === -1) {
 			parsedDate.endOf(lowerCaseFormat.indexOf('m') === -1 ? 'year' : 'month');
 		}
 

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
@@ -103,6 +103,17 @@
 			assertEquals('20150105', result);
 		},
 
+		'test parsing an unambiguous localised date with endOfUnit flag set': function() {
+			var result = parser.parse('18 Mar 2015', {
+				inputFormats: ['LL'],
+				outputFormat: 'YYYYMMDD',
+				inputLocale: 'en-gb',
+				endOfUnit: true
+			});
+
+			assertEquals('20150318', result);
+		},
+
 		'test parsing does not make loose matches': function() {
 			var result = parser.parse('18 Mar 2015', {
 				inputFormats: ['YYYY']


### PR DESCRIPTION
LocalisedDateParser should not consider locale-specific date formats as ambiguous for parsing to end of unit.

Because of the way we were checking if a date format was ambiguous, locale-specific formats were always considered ambiguous. So with the endOfUnit flag set, these would always parse to the end of the year.

e.g. "18 March 2015" parses in "LL" format to "31 December 2015".

This PR addresses that by considering all locale-specific formats as unambiguous.