### PR TITLE
LocalisedDateFormatter fix

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/src/LocalisedDateFormatter.js
@@ -38,12 +38,15 @@ topiarist.implement(LocalisedDateFormatter, Formatter);
  * @param {string} [attributes.outputFormat='L'] Format of the output date, expressed with {@link http://momentjs.com/docs/#/parsing/string-format/|Moment.js format tokens}
  * @param {string} [attributes.inputLocale] Locale override for the input
  * @param {string} [attributes.outputLocale] Locale override for the output
- * @returns {string} The date, expressed in the output format
+ * @returns {string} The date expressed in the output format, or the input value if it could not be parsed in the input format
  */
 LocalisedDateFormatter.prototype.format = function(date, attributes) {
 	attributes.inputFormats = [attributes.inputFormat];
 	attributes.outputFormat = attributes.outputFormat || 'L';
-	return this.localisedDateParsingUtil.parse(date, attributes);
+
+	var result = this.localisedDateParsingUtil.parse(date, attributes);
+
+	return typeof result === 'undefined' ? date : result;
 };
 
 module.exports = LocalisedDateFormatter;

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
@@ -21,13 +21,13 @@
 			assertEquals('25012015', result);
 		},
 
-		'test formatting failure': function() {
-			var result = formatter.format('', {
+		'test formatting failure should return original string': function() {
+			var result = formatter.format('abc', {
 				inputFormat: 'YYYYMMDD',
 				outputFormat: 'DDMMYYYY'
 			});
 
-			assertUndefined(result);
+			assertEquals('abc', result);
 		},
 
 		'test english localised format': function() {


### PR DESCRIPTION
Unlike parsers, which return null or undefined if they fail to parse, formatters are usually expected to return a value regardless. Otherwise, invalid inputs can be removed from the view as a result of formatting. If the LocalisedDateFormatter gets an input that doesn't match the input format, it should just return the input value.