### PR TITLE
BRLocaleProvider modifying read only array

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/locale/BRLocaleProvider.js
+++ b/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/locale/BRLocaleProvider.js
@@ -64,7 +64,7 @@ function getBrowserAcceptedLocales() {
 	var userAcceptedLocales;
 
 	if (navigator.languages) {
-		userAcceptedLocales = navigator.languages;
+		userAcceptedLocales = navigator.languages.slice(0);
 	}
 	else if (navigator.language) {
 		userAcceptedLocales = [navigator.language];


### PR DESCRIPTION
On line 82 this read only array is being modified. This throws an exception in Firefox. We can clone the array with slice(0) to prevent this issue.