### PR TITLE
We need a selectionField which does not pick up "random" value when opti...

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
@@ -4,30 +4,30 @@
 
 /**
  * Constructs a new instance of <code>SelectionField</code>.
- * 
+ *
  * @class
  * @alias module:br/presenter/node/SelectionField
  * @extends module:br/presenter/node/PresentationNode
- * 
+ *
  * @classdesc
  * A <code>PresentationNode</code> containing all of the attributes necessary to
  * model a selection field on screen.
- * 
+ *
  * <p>Selection fields can be rendered using a number of different controls:</p>
- * 
+ *
  * <ul>
  *   <li>radio buttons</li>
  *   <li>select box</li>
  *   <li>combo box</li>
  *   <li>toggle switch (only when there are exactly two options)</li>
  * </ul>
- * 
+ *
  * <p>By default, selection fields automatically add a validator for the case where the
  * currently entered {@link #value} isn't one of the available {@link #options} &mdash; this can
  * occur when you render the selection field using a combo box, or the underlying options
  * change so the currently selected value is no longer an available option. You can disable these
  * validation errors by invoking {@link #allowInvalidSelections} with <code>true</code>.</p>
- * 
+ *
  * @param {Object} vOptions The list of available options, either using an array, a map or an {@link module:br/presenter/node/OptionsNodeList}.
  * @param {Object} vValue (optional) The initial value of the field, either using a primitive type or an {@link module:br/presenter/property/EditableProperty}.
  */
@@ -35,37 +35,40 @@ br.presenter.node.SelectionField = function(vOptions, vValue)
 {
 	/** @private */
 	this.m_bAutomaticallyUpdateValueWhenOptionsChange = false;
-	
+
+	/** @private */
+	this.m_bAllowEmptySelection = false;
+
 	/**
 	 * The textual label associated with the selection field.
 	 * @type br.presenter.property.WritableProperty
 	 */
 	this.label = new br.presenter.property.WritableProperty("");
-	
+
 	/**
 	 * The currently selected option, or potentially any string the user has entered if being displayed with a combo-box.
 	 * @type br.presenter.property.WritableProperty
 	 */
 	this.value = null;
-	
+
 	/**
 	 * A boolean property that is <code>true</code> if {@link #value} has any validation errors, and <code>false</code> otherwise.
 	 * @type br.presenter.property.WritableProperty
 	 */
 	this.hasError = new br.presenter.property.WritableProperty(false);
-	
+
 	/**
 	 * A textual description of the currently failing validation message when {@link #hasError} is <code>true</code>.
 	 * @type br.presenter.property.WritableProperty
 	 */
 	this.failureMessage = new br.presenter.property.WritableProperty();
-	
+
 	/**
 	 * A boolean property representing whether the selection field is enabled or not.
 	 * @type br.presenter.property.WritableProperty
 	 */
 	this.enabled = new br.presenter.property.WritableProperty(true);
-	
+
 	/**
 	 * A boolean property representing whether the selection field is visible or not.
 	 * @type br.presenter.property.WritableProperty
@@ -90,10 +93,10 @@ br.presenter.node.SelectionField = function(vOptions, vValue)
 	if((vValue instanceof br.presenter.property.Property) && !(vValue instanceof br.presenter.property.EditableProperty)){
 		throw new br.Errors.InvalidParametersError("SelectionField constructor: can't pass non-editable property as parameter");
 	}
-	
+
 	/** @private */
 	this.m_vDefaultValue = null;
-	
+
 	if(vValue instanceof br.presenter.property.EditableProperty){
 		this.m_vDefaultValue = vValue.getValue();
 		this.value = vValue;
@@ -109,14 +112,14 @@ br.presenter.node.SelectionField = function(vOptions, vValue)
 
 		this.value = new br.presenter.property.EditableProperty(this.m_vDefaultValue);
 	}
-	
+
 	/** @private */
 	this.m_oValidSelectionValidator = new br.presenter.validator.ValidSelectionValidator(this.options);
 	this.value.addValidator(this.m_oValidSelectionValidator);
-	
+
 	/** @private */
 	this.m_oValueListener = new br.presenter.node.FieldValuePropertyListener(this);
-	
+
 	// validate the initial values
 	this.value.forceValidation();
 
@@ -132,11 +135,11 @@ br.Core.extend(br.presenter.node.SelectionField, br.presenter.node.PresentationN
 /**
  * Whether the selection field displays a validation error if the selected {@link #value} is not a member of
  * the {@link #options} array.
- * 
+ *
  * <p>Invalid selections cause validation errors by default, but this may not always be the desired behaviour,
  * for example if the <code>SelectionField</code> is being displayed using a combo-box, where the {@link #options}
  * are acting merely as suggestions, rather than as the absolute set of options.</p>
- * 
+ *
  * @param {boolean} bAllowInvalidSelections Invalid selections are allowed when set to <code>true</code>.
  */
 br.presenter.node.SelectionField.prototype.allowInvalidSelections = function(bAllowInvalidSelections)
@@ -147,17 +150,31 @@ br.presenter.node.SelectionField.prototype.allowInvalidSelections = function(bAl
 /**
  * Whether the selection field automatically picks a new {@link #value} when the underlying {@link #options}
  * change.
- * 
+ *
  * <p>If the underlying {@link #options} change, so that the new list of {@link #options} no longer includes
  * the currently selected {@link #value}, a validation error will be displayed by default. In some circumstances,
  * it may make sense to have the selection field automatically pick a new value automatically.</p>
- * 
+ *
  * @param {boolean} bAutomaticallyUpdate
  * @see #allowInvalidSelections
  */
 br.presenter.node.SelectionField.prototype.automaticallyUpdateValueWhenOptionsChange = function(bAutomaticallyUpdate)
 {
 	this.m_bAutomaticallyUpdateValueWhenOptionsChange = bAutomaticallyUpdate;
+};
+
+/**
+ * Whether the selection field leave {@link #value} empty when the underlying {@link #options} change and new list
+ * of {@link #options} no longer includes currently selected {@link #value}. In some circumstances it makes sense
+ * to force user to pick new value instead of choosing one for him automatically.
+ *
+ * @param {boolean} bAllowEmptySelection Empty selection is allowed when set to <code>true</code>
+ * @see #automaticallyUpdateValueWhenOptionsChange
+ * @returns {br.presenter.node.SelectionField}
+ */
+br.presenter.node.SelectionField.prototype.allowEmptySelection = function(bAllowEmptySelection)
+{
+	this.m_bAllowEmptySelection = bAllowEmptySelection;
 };
 
 /**
@@ -174,15 +191,17 @@ br.presenter.node.SelectionField.prototype._automaticallyUpdateValueOnOptionsCha
 		var pOptions = this.options.getOptions();
 		if(pOptions.length > 0)
 		{
-			var mOptions = br.util.MapUtility.addArrayToMap({}, pOptions);
-			
-			// if the currently selected value is no longer one of the available options, then revert to default or the first available option
-			if(!mOptions[this.value.getValue()])
-			{
-				var vNewValue = (mOptions[this.m_vDefaultValue]) ? this.m_vDefaultValue : pOptions[0].value.getValue();
-				var oValueProperty = this.value;
-				
-				oValueProperty.setUserEnteredValue(vNewValue);
+			// if the currently selected value is no longer one of the available options, then revert value into valid state
+			if (!this.options.getOptionByValue(this.value.getValue())) {
+				if (this.m_bAllowEmptySelection) {
+					// revert back to default value or force user to choose new value
+					var vNewValue = (this.options.getOptionByValue(this.m_vDefaultValue)) ? this.m_vDefaultValue : "";
+				}
+				else {
+					// revert back to default value or use first possible value
+					var vNewValue = (this.options.getOptionByValue(this.m_vDefaultValue)) ? this.m_vDefaultValue : pOptions[0].value.getValue();
+				}
+				this.value.setUserEnteredValue(vNewValue);
 			}
 		}
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/SelectionFieldTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/SelectionFieldTest.js
@@ -11,14 +11,14 @@ SelectionFieldTest.prototype.getTestValidator = function()
 	var fValidator = function()
 	{
 	};
-	
+
 	br.Core.extend(fValidator, br.presenter.validator.Validator);
 	fValidator.prototype.validate = function(sText, mAttributes, oValidationResult)
 	{
 		var bIsValid = (sText == "goodvalue");
 		oValidationResult.setResult(bIsValid, "must be 'goodvalue'");
 	};
-	
+
 	return new fValidator();
 };
 
@@ -36,7 +36,7 @@ SelectionFieldTest.prototype.test_defaultValueCanBePassedInViaConstructor = func
 	assertEquals("1a", "", oSelectionField.label.getValue());
 	assertEquals("1b", "option1", oSelectionField.value.getValue());
 	assertFalse("1c", oSelectionField.hasError.getValue());
-	
+
 	oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"], "option2");
 	assertEquals("2a", "", oSelectionField.label.getValue());
 	assertEquals("2b", "option2", oSelectionField.value.getValue());
@@ -80,7 +80,7 @@ SelectionFieldTest.prototype.test_anErrorIsDisplayedIfTheDefaultValueIsNotOneOfT
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"], "no-such-option");
 	assertEquals("1a", "", oSelectionField.label.getValue());
-	
+
 	assertEquals("1b", "no-such-option", oSelectionField.value.getValue());
 	assertTrue("1c", oSelectionField.hasError.getValue());
 };
@@ -120,7 +120,7 @@ SelectionFieldTest.prototype.test_theValueCanBeChangedToOneOfTheAvailableOptions
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	assertEquals("1a", "option1", oSelectionField.value.getValue());
-	
+
 	oSelectionField.value.setUserEnteredValue("option2");
 	assertEquals("2a", "option2", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
@@ -130,7 +130,7 @@ SelectionFieldTest.prototype.test_anErrorIsDisplayedIfTheValueIsChangedToANonExi
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	assertEquals("1a", "option1", oSelectionField.value.getValue());
-	
+
 	oSelectionField.value.setUserEnteredValue("no-such-option");
 	assertEquals("2a", "no-such-option", oSelectionField.value.getValue());
 	assertTrue("2b", oSelectionField.hasError.getValue());
@@ -141,7 +141,7 @@ SelectionFieldTest.prototype.test_aNonExistentOptionCanBeSelectedWithoutErroring
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	oSelectionField.allowInvalidSelections(true);
 	assertEquals("1a", "option1", oSelectionField.value.getValue());
-	
+
 	oSelectionField.value.setUserEnteredValue("no-such-option");
 	assertEquals("2a", "no-such-option", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
@@ -151,7 +151,7 @@ SelectionFieldTest.prototype.test_theOptionsCanBeSuccesfullyChangedIfTheyStillIn
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	assertEquals("1a", "option1", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions(["option0", "option1", "option2", "option3"]);
 	assertEquals("2a", "option1", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
@@ -161,7 +161,7 @@ SelectionFieldTest.prototype.test_changingTheOptionsCausesAnErrorIfTheOptionsNoL
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	assertEquals("1a", "option1", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions(["optionX", "optionY", "optionZ"]);
 	assertEquals("2a", "option1", oSelectionField.value.getValue());
 	assertTrue("2b", oSelectionField.hasError.getValue());
@@ -172,7 +172,7 @@ SelectionFieldTest.prototype.test_changingTheOptionsCanCauseAnErrorToBeFixedIfTh
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"], "no-such-option");
 	assertEquals("1a", "no-such-option", oSelectionField.value.getValue());
 	assertTrue("1b", oSelectionField.hasError.getValue());
-	
+
 	oSelectionField.options.setOptions(["no-such-option"]);
 	assertEquals("2a", "no-such-option", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
@@ -182,14 +182,14 @@ SelectionFieldTest.prototype.test_whenConfiguredTheValueRevertsToDefaultIfTheCur
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2", "option3"]);
 	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
-	
+
 	oSelectionField.value.setUserEnteredValue("option3");
 	assertEquals("1a", "option3", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2"]);
 	assertEquals("2a", "option1", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2", "option3"]);
 	assertEquals("3a", "option1", oSelectionField.value.getValue());
 };
@@ -198,14 +198,14 @@ SelectionFieldTest.prototype.test_whenConfiguredTheValueRevertsToASpecifiedDefau
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2", "option3"], "option2");
 	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
-	
+
 	oSelectionField.value.setUserEnteredValue("option3");
 	assertEquals("1a", "option3", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2"]);
 	assertEquals("2a", "option2", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2", "option3"]);
 	assertEquals("3a", "option2", oSelectionField.value.getValue());
 };
@@ -214,14 +214,14 @@ SelectionFieldTest.prototype.test_whenConfiguredTheValueRevertsToTheFirstOptionI
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2", "option3", "option4"], "option3");
 	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
-	
+
 	oSelectionField.value.setUserEnteredValue("option4");
 	assertEquals("1a", "option4", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2"]);
 	assertEquals("2a", "option1", oSelectionField.value.getValue());
 	assertFalse("2b", oSelectionField.hasError.getValue());
-	
+
 	oSelectionField.options.setOptions(["option1", "option2", "option3", "option4"]);
 	assertEquals("3a", "option1", oSelectionField.value.getValue());
 };
@@ -230,12 +230,26 @@ SelectionFieldTest.prototype.test_evenWhenConfiguredTheValueDoesntChangeIfTheUpd
 {
 	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"]);
 	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
-	
+
 	oSelectionField.value.setUserEnteredValue("option2");
 	assertEquals("1a", "option2", oSelectionField.value.getValue());
-	
+
 	oSelectionField.options.setOptions([]);
 	assertEquals("2a", "option2", oSelectionField.value.getValue());
+};
+
+SelectionFieldTest.prototype.test_whenConfiguredTheValueDefaultsToDefaultOrEmptyIfCurrentValueIsNoLongerAnOption = function()
+{
+	var oSelectionField = new br.presenter.node.SelectionField(["option1", "option2"], "option1");
+	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
+	oSelectionField.allowEmptySelection(true);
+	oSelectionField.value.setUserEnteredValue("option2");
+
+	oSelectionField.options.setOptions(["option1", "option3"]);
+	assertEquals("1a", "option1", oSelectionField.value.getValue());
+
+	oSelectionField.options.setOptions(["option2", "option3"]);
+	assertEquals("2a", "", oSelectionField.value.getValue());
 };
 
 SelectionFieldTest.prototype.test_thatTheEntireDerivationChainPropagatesCorrectly = function()
@@ -243,13 +257,13 @@ SelectionFieldTest.prototype.test_thatTheEntireDerivationChainPropagatesCorrectl
 	var oSelectionField = new br.presenter.node.SelectionField(["goodvalue", "badvalue"]);
 	oSelectionField.automaticallyUpdateValueWhenOptionsChange(true);
 	oSelectionField.value.addValidator(this.getTestValidator());
-	
+
 	assertEquals("1a", "goodvalue", oSelectionField.value.getValue());
 	assertFalse("1b", oSelectionField.hasError.getValue());
 	assertEquals("1c", "", oSelectionField.failureMessage.getValue());
-	
+
 	oSelectionField.options.setOptions(["badvalue"]);
-	
+
 	assertEquals("2a", "badvalue", oSelectionField.value.getValue());
 	assertTrue("2b", oSelectionField.hasError.getValue());
 	assertEquals("2c", "must be 'goodvalue'", oSelectionField.failureMessage.getValue());


### PR DESCRIPTION
We need a selectionField which does not pick up "random" value when options are changed. Instead we need to force user to repick value and throw validation error.

Use case:
Imagine you have accounts loaded in your app. You start a trade with a list of accounts from the model. But while you are in a middle of the trade your permission for selected account is rejected. So your permissioned accounts changed. Current behaviour will pick first account in list and populate your model with it. This will result in you trading on different account then you originally intended (which can be big mistake). This patch will set value of account in a model to "" which will lead into validation error and your trade will get rejected.

This is also fixing a bug where code bellow is effectively comparing labels of options with value of selectionField, which doesn't work when label is different then value of option:
```
var mOptions = br.util.MapUtility.addArrayToMap({}, pOptions);
if(!mOptions[this.value.getValue()])
```