### PR TITLE
Handle arrays in MapUtility#deepClone

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-util/src/br/util/MapUtility.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/src/br/util/MapUtility.js
@@ -334,8 +334,7 @@ MapUtility.clone = function(srcMap) {
 };
 
 /**
- * Creates a deep clone of the supplied map. Map references are copied to an arbitrary number of levels deep (note
- *  that non-map objects are not handled correctly)
+ * Creates a deep clone of the supplied map. Map references are copied to an arbitrary number of levels deep.
  *
  * @private
  * @param {Object} srcMap The map to clone.
@@ -343,9 +342,21 @@ MapUtility.clone = function(srcMap) {
  * @returns {Object} A deep clone of the map.
  */
 MapUtility.deepClone = function(srcMap) {
+	if (typeof srcMap !== 'object') {
+		return srcMap;
+	}
+
 	var clone = {};
 	for (var key in srcMap) {
-		clone[key] = typeof srcMap[key] === 'object' ? this.deepClone(srcMap[key]) : srcMap[key];
+		if (Array.isArray(srcMap[key])) {
+			clone[key] = srcMap[key].map(function(item) {
+				return this.deepClone(item);
+			}, this);
+		} else if (typeof srcMap[key] === 'object'){
+			clone[key] = this.deepClone(srcMap[key]);
+		} else {
+			clone[key] = srcMap[key];
+		}
 	}
 	return clone;
 };

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
@@ -436,3 +436,36 @@ MapUtilityTest.prototype.test_deepCloneClonesANestedMap = function() {
 	assertEquals(1, clonedMap.foo);
 	assertEquals(42, clonedMap.bar.baz);
 };
+
+MapUtilityTest.prototype.test_deepCloneHandlesArrays = function() {
+	var srcMap = {
+		foo: 1,
+		bar: [2, 3]
+	};
+	var clonedMap = MapUtility.deepClone(srcMap);
+
+	assertEquals(1, clonedMap.foo);
+	assertTrue(Array.isArray(clonedMap.bar));
+	assertEquals(2, clonedMap.bar[0]);
+	assertEquals(3, clonedMap.bar[1]);
+};
+
+MapUtilityTest.prototype.test_deepCloneClonesMapInArrays = function() {
+	var srcMap = {
+		foo: [
+			1,
+			{
+				bar: 2
+			},
+			['baz']
+		]
+	};
+	var clonedMap = MapUtility.deepClone(srcMap);
+
+	assertNotSame(srcMap.foo, clonedMap.foo);
+	assertEquals(1, clonedMap.foo[0]);
+	assertNotSame(srcMap.foo[1], clonedMap.foo[1]);
+	assertEquals(2, clonedMap.foo[1].bar);
+	assertNotSame(srcMap.foo[2], clonedMap.foo[2]);
+	assertEquals('baz', clonedMap.foo[2][0]);
+};

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
@@ -404,3 +404,35 @@ MapUtilityTest.prototype.test_hasAllKeys_emptyArguments = function()
 
 	assertTrue(MapUtility.hasAllKeys(mSource, mMap));
 };
+
+MapUtilityTest.prototype.test_deepCloneReturnsANewObject = function() {
+	var srcMap = {};
+	var clonedMap = MapUtility.deepClone(srcMap);
+
+	assertNotSame(srcMap, clonedMap);
+};
+
+MapUtilityTest.prototype.test_deepCloneClonesAMap = function() {
+	var srcMap = {
+		foo: 1,
+		bar: 'baz'
+	};
+	var clonedMap = MapUtility.deepClone(srcMap);
+
+	assertEquals(1, clonedMap.foo);
+	assertEquals('baz', clonedMap.bar);
+};
+
+MapUtilityTest.prototype.test_deepCloneClonesANestedMap = function() {
+	var srcMap = {
+		foo: 1,
+		bar: {
+			baz: 42
+		}
+	};
+	var clonedMap = MapUtility.deepClone(srcMap);
+
+	assertNotSame(srcMap.bar, clonedMap.bar);
+	assertEquals(1, clonedMap.foo);
+	assertEquals(42, clonedMap.bar.baz);
+};


### PR DESCRIPTION
Before it would convert Arrays into objects. Now it creates a new array and then recursively clones each element in that array.

This fixes #1301

<!---
@huboard:{"order":545.5,"milestone_order":1309,"custom_state":""}
-->
