### PR TITLE
also running tests in Travis on Java 8 - #1044

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk7
+- oraclejdk8
 git:
  depth: 200
 before_install:


### PR DESCRIPTION
adding Java 8 to the list of JDKs to run the Travis build on

<!---
@huboard:{"order":1314.0,"milestone_order":1314,"custom_state":""}
-->
