### PR TITLE
ensuring jetty-env is renamespaced propertly

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/command/ImportAppCommandTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/command/ImportAppCommandTest.java
@@ -199,11 +199,21 @@ public class ImportAppCommandTest extends SpecTest {
 	@Test
 	public void oldAppNamePrefixedAndFollowedByASlashIsReplacedInJettyEnv() throws Exception {
 		given(app).hasBeenCreated()
-		.and(app).containsFileWithContents("WEB-INF/jetty-env.xml", "/app/some-url" )
+			.and(app).containsFileWithContents("WEB-INF/jetty-env.xml", "/app/some-url" )
 			.and(brjs).commandHasBeenRun("export-app", "app")
 			.and(appJars).containsFile("brjs-lib1.jar");
 		when(brjs).runCommand("import-app", "../generated/exported-apps/app.zip", "imported-app", "importedns");
 		then(importedApp).fileContentsContains("WEB-INF/jetty-env.xml", "/imported-app/some-url");
+	}
+	
+	@Test
+	public void jndiConfigUrlIsRenamespaced() throws Exception {
+		given( brjs.app("myapp") ).hasBeenCreated()
+			.and( brjs.app("myapp") ).containsFileWithContents("WEB-INF/jetty-env.xml", "jdbc:h2:../generated/app/myapp/somedb/myapp;someDB=config" )
+			.and(brjs).commandHasBeenRun("export-app", "myapp")
+			.and(appJars).containsFile("brjs-lib1.jar");
+		when(brjs).runCommand("import-app", "../generated/exported-apps/myapp.zip", "imported-app", "importedns");
+		then(importedApp).fileContentsEquals("WEB-INF/jetty-env.xml", "jdbc:h2:../generated/app/imported-app/somedb/imported-app;someDB=config");
 	}
 	
 	@Test

--- a/brjs-core/src/main/java/org/bladerunnerjs/api/spec/engine/NodeVerifier.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/spec/engine/NodeVerifier.java
@@ -99,6 +99,14 @@ public abstract class NodeVerifier<N extends Node> {
 		
 	}
 	
+	public VerifierChainer fileContentsEquals(String fileName, String fileContents) throws Exception {
+		assertTrue("The file '" + fileName + "' did not exist at: " + node.file(fileName).getAbsoluteFile(), node.file(fileName).exists());
+		String actualContents = fileUtil.readFileToString(node.file(fileName));
+		assertTrue("Expected file to equal " + fileContents + " but didnt. Content was:\n"+actualContents, actualContents.equals(fileContents) );
+		
+		return verifierChainer;
+	}
+	
 	public VerifierChainer firstFileIsLarger(String filePath1, String filePath2) {
 		File file1 = node.file(filePath1);
 		File file2 = node.file(filePath2);

--- a/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/AppVerifier.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/AppVerifier.java
@@ -79,4 +79,5 @@ public class AppVerifier extends NodeVerifier<App> {
 		appJsLib = (appJsLib instanceof AppSdkJsLib) ? ((AppSdkJsLib) appJsLib).getWrappedJsLib() : appJsLib;
 		assertSame(appJsLib, appOverriddenNonBRLib);
 	}
+	
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/DirectoryVerifier.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/DirectoryVerifier.java
@@ -10,7 +10,6 @@ import org.bladerunnerjs.api.BladerunnerConf;
 import org.bladerunnerjs.api.memoization.MemoizedFile;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.api.spec.engine.VerifierChainer;
-import org.bladerunnerjs.utility.FileUtils;
 
 public class DirectoryVerifier {
 	private final MemoizedFile dir;

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/NodeImporter.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/NodeImporter.java
@@ -18,11 +18,13 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.NotFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.Aspect;
 import org.bladerunnerjs.api.AssetLocation;
 import org.bladerunnerjs.api.BRJS;
 import org.bladerunnerjs.api.Blade;
+import org.bladerunnerjs.api.BladerunnerConf;
 import org.bladerunnerjs.api.Bladeset;
 import org.bladerunnerjs.api.TestPack;
 import org.bladerunnerjs.api.TypedTestPack;
@@ -100,14 +102,10 @@ public class NodeImporter {
 
 		File jettyEnv = tempBrjsApp.file("WEB-INF/jetty-env.xml");
 		if (jettyEnv.isFile()) {
-			String prefixAndSuffixRegex = "([ /;])";
-			String jettyEnvContent = org.apache.commons.io.FileUtils.readFileToString(jettyEnv);
-			Matcher matcher = Pattern.compile(prefixAndSuffixRegex+oldAppName+prefixAndSuffixRegex).matcher(jettyEnvContent);
-			if (matcher.find()) {
-				findAndReplaceInTextFile(tempBrjs, jettyEnv, prefixAndSuffixRegex+oldAppName+prefixAndSuffixRegex, matcher.group(1)+targetApp.getName()+matcher.group(2));
-			}
-			else {
-				//do nothing - we are still keeping the old file content
+			String jettyXmlContent = org.apache.commons.io.FileUtils.readFileToString(jettyEnv, targetApp.root().bladerunnerConf().getDefaultFileCharacterEncoding());
+			String newJettyXmlContent = StringUtils.replacePattern(jettyXmlContent, "([ /;])"+oldAppName+"([ /;])", "$1"+targetApp.getName()+"$2");
+			if (!jettyXmlContent.equals(newJettyXmlContent)) {
+				org.apache.commons.io.FileUtils.write(jettyEnv, newJettyXmlContent);
 			}
 		}
 		
@@ -148,7 +146,7 @@ public class NodeImporter {
 		return brjs;
 	}
 	
-	private static void renameBladeset(Bladeset bladeset, String sourceAppRequirePrefix, String sourceBladesetRequirePrefix) throws IOException {
+	private static void renameBladeset(Bladeset bladeset, String sourceAppRequirePrefix, String sourceBladesetRequirePrefix) throws IOException, ConfigException {
 		updateRequirePrefix(bladeset, sourceAppRequirePrefix, sourceBladesetRequirePrefix, bladeset.requirePrefix());
 		
 		renameTestLocations(bladeset.testTypes(), sourceAppRequirePrefix, sourceBladesetRequirePrefix, bladeset.requirePrefix());
@@ -163,7 +161,7 @@ public class NodeImporter {
 		}
 	}
 	
-	private static void renameTestLocations(List<TypedTestPack> testTypes, String sourceAppRequirePrefix, String sourceLocationRequirePrefix, String requirePrefix) throws IOException{
+	private static void renameTestLocations(List<TypedTestPack> testTypes, String sourceAppRequirePrefix, String sourceLocationRequirePrefix, String requirePrefix) throws IOException, ConfigException {
 		
 		for(TypedTestPack typedTestPack : testTypes)
 		{
@@ -173,7 +171,7 @@ public class NodeImporter {
 		}		
 	}
 	
-	private static void updateRequirePrefix(AssetContainer assetContainer, String sourceAppRequirePrefix, String sourceRequirePrefix, String targetRequirePrefix) throws IOException {
+	private static void updateRequirePrefix(AssetContainer assetContainer, String sourceAppRequirePrefix, String sourceRequirePrefix, String targetRequirePrefix) throws IOException, ConfigException {
 		if(!sourceRequirePrefix.equals(targetRequirePrefix)) {
 			for(AssetLocation assetLocation : assetContainer.assetLocations()) {
 				if(assetLocation.dir().exists()) {
@@ -194,14 +192,14 @@ public class NodeImporter {
 		}
 	}
 	
-	private static void findAndReplaceInAllTextFiles(BRJS brjs, File rootRenameDirectory, String sourceRequirePrefix, String targetRequirePrefix) throws IOException
+	private static void findAndReplaceInAllTextFiles(BRJS brjs, File rootRenameDirectory, String sourceRequirePrefix, String targetRequirePrefix) throws IOException, ConfigException
 	{
 		IOFileFilter dontMatchWebInfDirFilter = new NotFileFilter( new NameFileFilter("WEB-INF") );
 		Collection<File> findAndReplaceFiles = FileUtils.listFiles(rootRenameDirectory, TrueFileFilter.INSTANCE, dontMatchWebInfDirFilter);
 		findAndReplaceInTextFiles(brjs, findAndReplaceFiles, sourceRequirePrefix, targetRequirePrefix);
 	}
 	
-	private static void findAndReplaceInTextFiles(BRJS brjs, Collection<File> files, String sourceRequirePrefix, String targetRequirePrefix) throws IOException
+	private static void findAndReplaceInTextFiles(BRJS brjs, Collection<File> files, String sourceRequirePrefix, String targetRequirePrefix) throws IOException, ConfigException
 	{
 		for (File f : files) {
 			if (f.length() != 0) {
@@ -214,7 +212,7 @@ public class NodeImporter {
 		return true;
 	}
 	
-	private static void findAndReplaceInTextFile(BRJS brjs, File file, String oldRequirePrefix, String newRequirePrefix) throws IOException
+	private static void findAndReplaceInTextFile(BRJS brjs, File file, String oldRequirePrefix, String newRequirePrefix) throws IOException, ConfigException
 	{
 		for (String extension : ImageIO.getReaderFormatNames()) {
 			if (file.getName().endsWith(extension)) {
@@ -222,7 +220,7 @@ public class NodeImporter {
 			}
 		}
 		
-		String content = org.apache.commons.io.FileUtils.readFileToString(file);
+		String content = org.apache.commons.io.FileUtils.readFileToString(file, brjs.bladerunnerConf().getDefaultFileCharacterEncoding());
 		String updatedContent = findAndReplaceInText(content, oldRequirePrefix, newRequirePrefix);
 		
 		if (!content.equals(updatedContent)) {

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/FileUtils.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/FileUtils.java
@@ -1,8 +1,6 @@
 package org.bladerunnerjs.utility;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collection;
 


### PR DESCRIPTION
- fixing the find/replace logic for the app name in jetty-env
- making sure we use the BRJS conf file encoding when reading in files to re-namepsace them

This is needed for the 0.15.4 release. @dchambers can you dev review ASAP so @thanhc can test and merge?