### PR TITLE
Add support for OptionsNodeList in popup windows

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/OptionsNodeList.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/OptionsNodeList.js
@@ -151,7 +151,7 @@ br.presenter.node.OptionsNodeList.prototype._getOptionObjects = function(vOption
 
 	var pResult = [];
 
-	if(vOptions instanceof Array)
+	if(Object.prototype.toString.call(vOptions) === '[object Array]')
 	{
 		for(var i = 0; i < vOptions.length; i++)
 		{


### PR DESCRIPTION
Fixed a bug where OptionsNodeList would not generate a correct array of options when running in a popup windows.

Arrays coming from main window will fail "vOptions instanceof Array" checks.
Instead use toString to check for "[object Array]"

<!---
@huboard:{"order":657.5,"milestone_order":1325,"custom_state":""}
-->
