### PR TITLE
Added check to see whether app.conf exists in the containing or ancestor...

### DIFF
--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/testIntegration/IntegrationTestFinder.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/testIntegration/IntegrationTestFinder.java
@@ -51,8 +51,10 @@ public class IntegrationTestFinder
 		
 		File containingDir = dir.getParentFile().getParentFile();
 		File ancestorContainingDir = containingDir.getParentFile();
+
 		if (validTestDir && !(containingDir.getName().endsWith("-aspect") || ancestorContainingDir.getName().endsWith("-aspect") || 
-				containingDir.getName().equals("workbench") || ancestorContainingDir.getName().equals("workbench")))
+				(new File(containingDir, "app.conf").exists() || new File(ancestorContainingDir, "app.conf").exists()) ||
+				containingDir.getName().equals("workbench") || ancestorContainingDir.getName().equals("workbench") ))
 		{
 			validTestDir = false;
 			logger.info("Found integration test directory in "+dir.getPath()+"\n"+

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/testIntegration/IntegrationTestFinder.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/testIntegration/IntegrationTestFinder.java
@@ -53,7 +53,7 @@ public class IntegrationTestFinder
 		File ancestorContainingDir = containingDir.getParentFile();
 
 		if (validTestDir && !(containingDir.getName().endsWith("-aspect") || ancestorContainingDir.getName().endsWith("-aspect") || 
-				(new File(containingDir, "app.conf").exists() || new File(ancestorContainingDir, "app.conf").exists()) ||
+				new File(containingDir, "app.conf").exists() || new File(ancestorContainingDir, "app.conf").exists() ||
 				containingDir.getName().equals("workbench") || ancestorContainingDir.getName().equals("workbench") ))
 		{
 			validTestDir = false;


### PR DESCRIPTION
... directory for determining whether it's the root of the app.

Fixes issue #1297.

We needed to add a check to see whether the test-integration folder is contained in the root app directory, which has been done by checking the existence of the 'app.conf' file.

<!---
@huboard:{"order":1330.0,"milestone_order":1330,"custom_state":""}
-->
