### PR TITLE
adding an aliasDataPlugin that returns alias data for the BundlableNode

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/testpack/AspectTestPackBundlingTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/testpack/AspectTestPackBundlingTest.java
@@ -97,4 +97,15 @@ public class AspectTestPackBundlingTest extends SpecTest
 		when(aspectUTs).requestReceivedInDev("i18n/en.js", response);
 		then(response).containsText("\"appns.prop\": \"val\"");
 	}
+	
+	@Test
+	public void testPackBundlesCanBeCreatedForAspectDefaultTechTests() throws Exception {
+		given(aspect).hasClass("appns/Class1")
+			.and( aspect.testType("unit").defaultTestTech() ).hasNamespacedJsPackageStyle()
+			.and( aspect.testType("unit").defaultTestTech() ).testRefersTo("pkg/test.js", "appns.Class1")
+			.and( aspect.testType("unit").defaultTestTech() ).containsResourceFileWithContents("en.properties", "appns.prop=val");
+		when( aspect.testType("unit").defaultTestTech() ).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then( aspect.testType("unit").defaultTestTech() ).srcOnlyBundledFilesEquals( aspect.file("src/appns/Class1.js") );
+	}
+	
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/require/AliasDataRequirePlugin.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/require/AliasDataRequirePlugin.java
@@ -1,0 +1,40 @@
+package org.bladerunnerjs.plugin.require;
+
+import org.bladerunnerjs.api.Asset;
+import org.bladerunnerjs.api.BRJS;
+import org.bladerunnerjs.api.BundlableNode;
+import org.bladerunnerjs.api.model.exception.RequirePathException;
+import org.bladerunnerjs.api.plugin.RequirePlugin;
+import org.bladerunnerjs.api.plugin.base.AbstractRequirePlugin;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
+
+
+public class AliasDataRequirePlugin extends AbstractRequirePlugin implements RequirePlugin
+{
+	
+	private RequirePlugin defaultRequirePlugin;
+
+	@Override
+	public void setBRJS(BRJS brjs)
+	{
+		this.defaultRequirePlugin = brjs.plugins().requirePlugin("default");
+	}
+
+	@Override
+	public String getPluginName()
+	{
+		return "alias";
+	}
+
+	@Override
+	public Asset getAsset(BundlableNode bundlableNode, String requirePathSuffix) throws RequirePathException
+	{
+		String requirePath = getPluginName()+"!"+requirePathSuffix;
+		if (requirePath.equals(AliasDataSourceModule.PRIMARY_REQUIRE_PATH)) {
+			return bundlableNode.asset(requirePath);
+		}
+		return defaultRequirePlugin.getAsset(bundlableNode, requirePath);
+	}
+	
+}
+

--- a/plugins/brjs-plugins/src/main/resources/META-INF/services/org.bladerunnerjs.api.plugin.RequirePlugin
+++ b/plugins/brjs-plugins/src/main/resources/META-INF/services/org.bladerunnerjs.api.plugin.RequirePlugin
@@ -1,2 +1,3 @@
 org.bladerunnerjs.plugin.require.DefaultRequirePlugin
 org.bladerunnerjs.plugin.require.ServiceRequirePlugin
+org.bladerunnerjs.plugin.require.AliasDataRequirePlugin

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/aliasing/AliasAndServiceBundlingTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/aliasing/AliasAndServiceBundlingTest.java
@@ -1029,6 +1029,16 @@ public class AliasAndServiceBundlingTest extends SpecTest
 	 * End Alias Model Testing *
 	 */
 	
-	
+	@Test
+	public void testPackBundlesCanBeCreatedForAspectDefaultTechTestsWhereAliasRegistryIsUsed() throws Exception {
+		given(aspect).classRequires("appns/Class1", "alias!$data")
+			.and( aspect.testType("unit").defaultTestTech() ).hasNamespacedJsPackageStyle()
+			.and( aspect.testType("unit").defaultTestTech() ).testRefersTo("pkg/test.js", "appns.Class1")
+			.and( aspect.testType("unit").defaultTestTech() ).containsResourceFileWithContents("en.properties", "appns.prop=val")
+			.and(sdkLib).hasClass("br/AliasRegistry");
+		when( aspect.testType("unit").defaultTestTech() ).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsText("define('alias!$data'")
+			.and(response).containsText("define('appns/Class1'");
+	}
 	
 }


### PR DESCRIPTION
- adds an AliasData require plugin that returns the alias data for the BundlableNode instead of trying to find it from scope asset containers
- prevents ambiguous require path exceptions and from returning the asset data for a different bundlable node that the one we are using
- should also fix the current failures in `develop`

<!---
@huboard:{"order":1337.0,"milestone_order":1332,"custom_state":""}
-->
