### PR TITLE
Stop using jsunit extensions

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-component/test-unit/tests/ComponentTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-component/test-unit/tests/ComponentTest.js
@@ -1,9 +1,6 @@
 (function() {
 	var Component = require('br/component/Component');
 
-	br.Core.thirdparty('jsunitextensions');
-	br.Core.thirdparty('mock4js');
-
 	ComponentTest = TestCase("ComponentTest");
 
 	ComponentTest.prototype.createSetDisplayFrameComponent = function()

--- a/brjs-sdk/sdk/libs/javascript/br-component/test-unit/tests/testing/ComponentFixtureTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-component/test-unit/tests/testing/ComponentFixtureTest.js
@@ -1,4 +1,3 @@
-br.Core.thirdparty('jsunitextensions');
 br.Core.thirdparty('mock4js');
 
 ComponentFixtureTest = TestCase("ComponentFixtureTest");

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/DateFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/DateFormatterTest.js
@@ -1,6 +1,4 @@
 (function() {
-	require('jsunitextensions');
-
 	DateFormatterTest = TestCase("DateFormatterTest");
 
 	var DateFormatter = require('br/presenter/formatter/DateFormatter');
@@ -29,7 +27,7 @@
 
 		// convert from date string to object
 		this.assertSimpleParse = function(sDatePicture, sDateInput, oDateOutput) {
-			assertVariantEquals(sDatePicture, oDateOutput, that.oFormatter.parseDate(sDateInput, sDatePicture));
+			assertEquals(sDatePicture, oDateOutput, that.oFormatter.parseDate(sDateInput, sDatePicture));
 		};
 
 		this.assertFormat = function(sOutputFormat, sDateOutput, sDateInput, sInputFormat) {
@@ -39,7 +37,7 @@
 			};
 			var sExpected = sDateOutput;
 			var sActual = that.oFormatter.format(sDateInput, mAttributes);
-			assertVariantEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
+			assertEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
 		};
 
 		this.assertFormatWithTimezone = function(sOutputFormat, sDateOutput, sDateInput, sInputFormat) {
@@ -50,7 +48,7 @@
 			};
 			var sExpected = sDateOutput;
 			var sActual = that.oFormatter.format(sDateInput, mAttributes);
-			assertVariantEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
+			assertEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
 		};
 
 		this.fixTimeZone = function(nAdjustment) {

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/LocalisedDateFormatterTest.js
@@ -1,7 +1,4 @@
 (function() {
-
-	require('jsunitextensions');
-
 	var LocalisedDateFormatter = require('br/formatting/LocalisedDateFormatter');
 	var formatter;
 

--- a/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/ThousandsFormatterTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-formatting/tests/test-unit/js-test-driver/tests/ThousandsFormatterTest.js
@@ -1,6 +1,5 @@
 (function() {
 	ThousandsFormatterTest = TestCase("ThousandsFormatterTest");
-	require('jsunitextensions');
 	var ThousandsFormatter = require('br/presenter/formatter/ThousandsFormatter');
 
 	ThousandsFormatterTest.prototype.setUp = function()

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/LocalisedNumberTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/LocalisedNumberTest.js
@@ -1,6 +1,4 @@
 (function() {
-	// Hack to get jsunitextensions bundled but not throw JS error
-	//require("jsunitextensions");
 	LocalisedNumberTest = TestCase("LocalisedNumberTest");
 
 	LocalisedNumberTest.prototype.setUp = function()

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/DateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/DateParserTest.js
@@ -1,5 +1,4 @@
 (function() {
-	require("jsunitextensions");
 	var DateParser = require('br/parsing/DateParser');
 
 	DateParserTest = TestCase("DateParserTest");
@@ -22,7 +21,7 @@
 		this._assertParse = function(sDateInput, sDateOutput, mAttributes) {
 			var sExpected = sDateOutput;
 			var sActual = that.oParser.parse(sDateInput, mAttributes);
-			assertVariantEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
+			assertEquals(sDateInput + " -> " + sDateOutput, sExpected, sActual);
 		};
 
 		this.assertParse = function(sOutputFormat, sDateOutput, sDateInput, sInputFormat) {

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedDateParserTest.js
@@ -1,7 +1,4 @@
 (function() {
-
-	require('jsunitextensions');
-
 	var LocalisedDateParser = require('br/parsing/LocalisedDateParser');
 	var parser;
 

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/PresentationModelTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/PresentationModelTest.js
@@ -1,4 +1,3 @@
-br.Core.thirdparty('jsunitextensions');
 br.Core.thirdparty('mock4js');
 
 PresentationModelTest = TestCase("PresentationModelTest");

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerLocaleUtilTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/control/datefield/JQueryDatePickerLocaleUtilTest.js
@@ -1,6 +1,5 @@
 (function() {
 	require('jsmockito');
-	require('jstestdriverextensions');
 
 	var subrealm;
 	var spyI18n;

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/PresentationNodeTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/node/PresentationNodeTest.js
@@ -1,5 +1,3 @@
-br.Core.thirdparty('jsunitextensions');
-
 PresentationNodeTest = TestCase("PresentationNodeTest");
 
 PresentationNodeTest.prototype.test_nodes = function()

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/testing/PresenterComponentFixtureTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/testing/PresenterComponentFixtureTest.js
@@ -1,5 +1,4 @@
 br.Core.thirdparty('mock4js');
-br.Core.thirdparty('jsunitextensions');
 
 PresenterComponentFixtureTest = TestCase("PresenterComponentFixtureTest");
 

--- a/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/test/ViewFixtureTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/test/ViewFixtureTest.js
@@ -1,5 +1,3 @@
-br.Core.thirdparty('jsunitextensions');
-
 var ViewFixtureTest = TestCase("ViewFixtureTest");
 
 ViewFixtureTest.prototype.setUp = function() {

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ArrayUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ArrayUtilityTest.js
@@ -1,4 +1,3 @@
-require('jsunitextensions');
 require('mock4js');
 
 var ArrayUtility = require('br/util/ArrayUtility');

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ElementUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ElementUtilityTest.js
@@ -1,6 +1,3 @@
-require('jsunitextensions');
-require('mock4js');
-
 var ElementUtility = require('br/util/ElementUtility');
 
 ElementUtilityTest = TestCase('ElementUtilityTest');

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/MapUtilityTest.js
@@ -1,5 +1,3 @@
-require('jsunitextensions');
-
 var MapUtility = require('br/util/MapUtility');
 
 var MapUtilityTest = TestCase("MapUtilityTest");

--- a/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ObservableTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-util/test-unit/tests/br/util/ObservableTest.js
@@ -1,4 +1,3 @@
-require('jsunitextensions');
 require('mock4js');
 
 var Observable = require('br/util/Observable');

--- a/brjs-sdk/sdk/libs/javascript/br-viewhandler-tests_NODIST/test-unit/tests/br/test/DoesNotHaveClassTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-viewhandler-tests_NODIST/test-unit/tests/br/test/DoesNotHaveClassTest.js
@@ -1,4 +1,3 @@
-require("jsunitextensions");
 DoesNotHaveClassTest = TestCase("DoesNotHaveClassTest");
 
 require('br/test/ViewFixture');

--- a/brjs-sdk/sdk/libs/javascript/br/test-unit/tests/AliasRegistryTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br/test-unit/tests/AliasRegistryTest.js
@@ -1,10 +1,9 @@
 (function(){
 	"use strict";
-	
+
 	// TODO: this line can be deleted once CommonJs supports aliases
 	require('br/workaround/CommonJsAliasWorkaround');
 
-	require("jstestdriverextensions");
 	require("jsmockito");
 	var br = require('br/Core');
 	var Errors = require('br/Errors');
@@ -106,7 +105,7 @@
 				"interface":"br/Alias2Interface",
 				"interfaceName":"br.Alias2Interface"
 			}});
-		
+
 		assertException("Should throw an error if the alias is not implementor of the alias interface",
 			function() {
 				aliasRegistry.getClass('some.alias1');


### PR DESCRIPTION
This pull-request does not change any functionality, but reduces our dependence on the `jstestdriverextensions` and `jsunitextensions` libraries where this wasn't actually needed.

<!---
@huboard:{"order":1359.0,"milestone_order":1359,"custom_state":""}
-->
