### PR TITLE
Initialize knockout plug-ins after template added to page

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-knockout/src/br/knockout/KnockoutComponent.js
+++ b/brjs-sdk/sdk/libs/javascript/br-knockout/src/br/knockout/KnockoutComponent.js
@@ -24,8 +24,6 @@ function KnockoutComponent(sTemplateId, vPresentationModel) {
   this.m_sTemplateId = sTemplateId;
   this.m_eTemplate = this._getTemplate(sTemplateId);
   this.m_oPresentationModel = vPresentationModel;
-  this.m_bViewBound = false;
-  this.m_bViewAttached = false;
 }
 br.implement( KnockoutComponent, Component );
 
@@ -48,14 +46,13 @@ KnockoutComponent.prototype.setDisplayFrame = function(frame) {
   this.m_oFrame = frame;
 
   frame.setContent(this.getElement());
+
+  frame.on('attach', function() {
+    ko.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
+  }.bind(this));
 };
 
 KnockoutComponent.prototype.getElement = function() {
-  if (!this.m_bViewBound) {
-    this.m_bViewBound = true;
-    ko.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
-  }
-
   return this.m_eTemplate;
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-knockout/src/br/knockout/KnockoutComponent.js
+++ b/brjs-sdk/sdk/libs/javascript/br-knockout/src/br/knockout/KnockoutComponent.js
@@ -45,11 +45,11 @@ br.extend(KnockoutComponent.TemplateNotFoundError, Errors.CustomError);
 KnockoutComponent.prototype.setDisplayFrame = function(frame) {
   this.m_oFrame = frame;
 
-  frame.setContent(this.getElement());
-
   frame.on('attach', function() {
     ko.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
   }.bind(this));
+
+  frame.setContent(this.getElement());
 };
 
 KnockoutComponent.prototype.getElement = function() {

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/component/PresenterComponent.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/component/PresenterComponent.js
@@ -117,11 +117,11 @@ PresenterComponent.prototype.setDisplayFrame = function(frame) {
 		frame.on(event, getEventHandler.call(this, event), this);
 	}, this);
 
-	frame.setContent(this.getElement());
-
 	frame.on('attach', function() {
 		presenter_knockout.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
 	}.bind(this));
+
+	frame.setContent(this.getElement());
 };
 
 PresenterComponent.prototype.getElement = function() {

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/component/PresenterComponent.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/component/PresenterComponent.js
@@ -30,7 +30,6 @@ function PresenterComponent(sTemplateId, vPresentationModel) {
 	this.m_eTemplate = this._getTemplate(sTemplateId);
 	this.m_sPresentationModel = null;
 	this.m_oPresentationModel = null;
-	this.m_bViewBound = false;
 	this.m_bViewAttached = false;
 	this.m_oFrame = null;
 	this.m_pLifecycleListeners = [];
@@ -120,14 +119,12 @@ PresenterComponent.prototype.setDisplayFrame = function(frame) {
 
 	frame.setContent(this.getElement());
 
+	frame.on('attach', function() {
+		presenter_knockout.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
+	}.bind(this));
 };
 
 PresenterComponent.prototype.getElement = function() {
-	if (!this.m_bViewBound) {
-		this.m_bViewBound = true;
-		presenter_knockout.applyBindings(this.m_oPresentationModel, this.m_eTemplate);
-	}
-
 	return this.m_eTemplate;
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-workbench/src/br/workbench/ui/Workbench.js
+++ b/brjs-sdk/sdk/libs/javascript/br-workbench/src/br/workbench/ui/Workbench.js
@@ -45,6 +45,7 @@ Workbench.prototype.displayComponent = function(oComponent, width, height)
 
 	this.center(simpleFrame.getElement());
 	document.body.appendChild(simpleFrame.getElement());
+	simpleFrame.trigger('attach');
 };
 
 /**

--- a/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/DashboardApp.js
+++ b/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/DashboardApp.js
@@ -10,11 +10,9 @@ brjs.dashboard.app.DashboardApp = function(oDashboardService, oPageUrlService, o
 	this.m_oPresentationModel = new brjs.dashboard.app.model.DashboardPresentationModel(oDashboardService, oPageUrlService, oWindowOpenerService, oLocalStorage, oBrowserDetector);
 	this.m_oPresenterComponent = new br.presenter.component.PresenterComponent("brjs.dashboard.app.root", this.m_oPresentationModel);
 
-	// TODO: update dashboard to use new component interface.
-	// TODO: add proper frame support
-	eDisplayElement.appendChild(this.m_oPresenterComponent.getElement());
-
-	//	this.m_oPresenterComponent.onOpen();
+	var frame = new br.component.SimpleFrame(this.m_oPresenterComponent, null, null);
+	eDisplayElement.appendChild(frame.getElement());
+	frame.trigger('attach');
 
 	this.m_bAppsLoaded = false;
 	oPageUrlService.addPageUrlListener(this._onPageUrlUpdated.bind(this), true);


### PR DESCRIPTION
This pull-request hopefully fixes these issues:

  1. #1372
  1. #1373
  1. #1374 

#1372 can be tested by using the workbench page from the `easytree` app within the [easytree-brjs-spike](https://github.com/dchambers/-easytree-brjs-spike) &mdash; without this pull-request it's not possible to expand or collapse the nodes within the tree.

**Note:** Except for the fact that CT are using their own version of `PresenterComponent`, there would otherwise be a high risk this change introduces backwards compatibility issues. Even so, there may be issues even in terms of BRJS only infrastructure.
