### PR TITLE
minor changes needed to make the appcache work with 1.0

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/BRJSCommander.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/spec/utility/BRJSCommander.java
@@ -179,4 +179,12 @@ public class BRJSCommander extends NodeCommander<BRJS> {
 		
 		return commanderChainer;
 	}
+	
+	public CommanderChainer hasVersion(String version)
+	{
+		specTest.appVersionGenerator.setVersion(version);
+		
+		return commanderChainer;
+	}
+	
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/commands/standard/ServeCommand.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/commands/standard/ServeCommand.java
@@ -1,6 +1,8 @@
 package org.bladerunnerjs.plugin.commands.standard;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.bladerunnerjs.api.BRJS;
 import org.bladerunnerjs.api.appserver.ApplicationServer;
@@ -79,11 +81,12 @@ public class ServeCommand extends JSAPArgsParsingCommandPlugin
 				appServer = getApplicationServer(parsedArgs);
 			}
 			
-			brjs.getAppVersionGenerator().setVersion( parsedArgs.getString("version") );
-			if (parsedArgs.getString("version").equals("dev")) {
-				brjs.getAppVersionGenerator().appendTimetamp(false);
+			String version = parsedArgs.getString("version");
+			if (!version.equals("dev") && !version.matches(".*\\-[0-9]+")) {
+				version += "-"+new SimpleDateFormat("yyyyMMddhhmmss").format(new Date());
 			}
-			
+			brjs.getAppVersionGenerator().setVersion(version);
+			brjs.getAppVersionGenerator().appendTimetamp(false);
 			
 			appServer.start();
 			brjs.fileObserver().start();


### PR DESCRIPTION
- adds a spec test method
- fixes the version and timestamp when `serve` is run rather than recalculating the timestamp each time the version is requested as it breaks the browser's appcache mechanism if the version changes