### PR TITLE
Manually creating elements for each HTML5 tags.

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-ie8-shim/ie8-shim.js
+++ b/brjs-sdk/sdk/libs/javascript/br-ie8-shim/ie8-shim.js
@@ -2,7 +2,7 @@ if((navigator.appName == 'Microsoft Internet Explorer') && (navigator.userAgent.
 {
 	// see <http://tatiyants.com/how-to-get-ie8-to-support-html5-tags-and-web-fonts/> for info
 	 var html5tags = ["article", "aside", "bdi", "details", "dialog", "figcaption", "figure", "footer", "header", "main", "mark", "menuitem", "meter", "nav", "progress", "rp", "rt", "ruby",
-	 					"section", "summary", "time", "wbr", "datalist", "keygen", "output", "canvas", "svg", "audio", "embed", "source", "track", "video"];
+	                  "section", "summary", "time", "wbr", "datalist", "keygen", "output", "canvas", "svg", "audio", "embed", "source", "track", "video"];
 	 for(var i = 0; i < html5tags.length; i++)
 	 {	 	
 	 	document.createElement(html5tags[i]);

--- a/brjs-sdk/sdk/libs/javascript/br-ie8-shim/ie8-shim.js
+++ b/brjs-sdk/sdk/libs/javascript/br-ie8-shim/ie8-shim.js
@@ -1,6 +1,14 @@
-// see <http://www.adequatelygood.com/2011/4/Replacing-setTimeout-Globally> for info
 if((navigator.appName == 'Microsoft Internet Explorer') && (navigator.userAgent.match(/MSIE ([0-9]+)/)[1] <= 8))
 {
+	// see <http://tatiyants.com/how-to-get-ie8-to-support-html5-tags-and-web-fonts/> for info
+	 var html5tags = ["article", "aside", "bdi", "details", "dialog", "figcaption", "figure", "footer", "header", "main", "mark", "menuitem", "meter", "nav", "progress", "rp", "rt", "ruby",
+	 					"section", "summary", "time", "wbr", "datalist", "keygen", "output", "canvas", "svg", "audio", "embed", "source", "track", "video"];
+	 for(var i = 0; i < html5tags.length; i++)
+	 {	 	
+	 	document.createElement(html5tags[i]);
+	 }
+
+	// see <http://www.adequatelygood.com/2011/4/Replacing-setTimeout-Globally> for info
 	var pProperties = ["alert", "setTimeout", "clearTimeout", "setInterval", "clearInterval"];
 	for(var i = 0, l = pProperties.length; i < l; ++i)
 	{


### PR DESCRIPTION
Fixes issue #1354.

The HTML5 tags needed to be created separately as elements for IE8. In addition to this, I have changed the brjstodo app to create the `section` after the js bundle, so that the shim would run before the element is created.

<!---
@huboard:{"order":1401.0,"milestone_order":1385,"custom_state":""}
-->
