### PR TITLE
Fix for Verifier parsing values with new line characters

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/GwtTestRunner.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/GwtTestRunner.js
@@ -377,7 +377,7 @@ GwtTestRunner.prototype._parseStatement = function(sStatement, nPhase) {
 
 	var newlinePlaceholder = "<!--space--!>";
 
-	sStatement = sStatement.replace("\n",newlinePlaceholder);
+	sStatement = sStatement.replace(new RegExp("\n", "g"), newlinePlaceholder);
 
 	this._updatePhase(nPhase, sStatement);
 
@@ -398,7 +398,7 @@ GwtTestRunner.prototype._parseStatement = function(sStatement, nPhase) {
 	var oStatement = {
 		property:(pStatement[1].trim()),
 		operator:pStatement[2],
-		propertyValue:this._getTypedPropertyValue(pStatement[3].replace(newlinePlaceholder,"\n"))
+		propertyValue:this._getTypedPropertyValue(pStatement[3].replace(new RegExp(newlinePlaceholder, "g"), "\n"))
 	};
 
 	if (nPhase === GwtTestRunner.WHEN_PHASE && oStatement.operator != "=>") {

--- a/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/testing/GwtTestRunnerTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/testing/GwtTestRunnerTest.js
@@ -592,6 +592,18 @@ GwtTestRunnerTest.prototype.testExceptionIsThrownIfDescriptionContainsInvalidCha
 	if (!passTest) fail("Expected test failure - invalid char in description");
 };
 
+GwtTestRunnerTest.prototype.test_valuesWithNewLinesAreParsedProperly = function()
+{
+	var oTestRunner = new br.test.GwtTestRunner("br.test.TestFixtureFactory");
+	oTestRunner.startTest();
+	
+	this.getFixture(oTestRunner, "propertyFixture").expects(once()).doGiven("prop", "1\n2");
+	this.getFixture(oTestRunner, "propertyFixture").expects(once()).doGiven("prop", "1\n2\n3\n4");
+	
+	oTestRunner.doGiven("propertyFixture.prop = '1\n2'");
+	oTestRunner.doGiven("propertyFixture.prop = '1\n2\n3\n4'");
+};
+
 GwtTestRunnerTest.prototype.test_xitCanBeUsedToDisableTestsWithoutBreakingChaining = function()
 {
 	var oTestRunner = new br.test.GwtTestRunner("br.test.TestFixtureFactory");


### PR DESCRIPTION
`GwtTestRunner.prototype._parseStatement` should perform a global token replace when it removes/reinstates new line characters. Otherwise it only supports values with a single new line.