### PR TITLE
Added Safari browser test tasks

### DIFF
--- a/brjs-sdk/build.gradle
+++ b/brjs-sdk/build.gradle
@@ -152,7 +152,7 @@ def createTestTask = { taskName, taskTestDir, taskTestType, browser ->
 }
 
 // "libs/javascript" is relative to the sdk directory
-[ "Chrome", "Firefox", "IE", "PhantomJS" ].each {
+[ "Chrome", "Firefox", "IE", "PhantomJS", "Safari" ].each {
 	def testJsTask = createTestTask "testJs${it}", "libs/javascript", "ALL", it.toLowerCase()
 	def testSystemAppsTask = createTestTask "testSystemApps${it}", "system-applications", "ALL", it.toLowerCase()
 	task "test${it}", dependsOn: [testJsTask, testSystemAppsTask]


### PR DESCRIPTION
No task is yet in place to test brjs on Safari. The test-runner config specifies using the browser installed on OSX rather than pulling in an external artifact, so all that is needed is the new tasks