### PR TITLE
Changed the safari test-runner command to launch safari

### DIFF
--- a/brjs-sdk/conf/test-runner.conf
+++ b/brjs-sdk/conf/test-runner.conf
@@ -19,8 +19,8 @@ browserPaths:
     chrome: ../build/browsers/chrome-mac/Chromium.app/Contents/MacOS/Chromium$$--incognito$$--user-data-dir=../build/browsers/profile/chromium
     firefox: ../build/browsers/firefox-mac/Firefox.app/Contents/MacOS/firefox$$-private
     firefox-webdriver: ../build/browsers/firefox-mac/Firefox.app/Contents/MacOS/firefox$$-private
-    safari: /Applications/Safari.app/Contents/MacOS/Safari
-# firefox on Mac doesnt use a custom profile because of a bug with the profile argument (https://bugzilla.mozilla.org/show_bug.cgi?id=673955)
+    # firefox on Mac doesnt use a custom profile because of a bug with the profile argument (https://bugzilla.mozilla.org/show_bug.cgi?id=673955)
+    safari: /usr/bin/open$$-a$$safari
   linux:
     phantomjs: ../build/browsers/phantomjs-linux-i686/bin/phantomjs$$../conf/phantomjs-runner.js
     chrome: ../build/browsers/chrome-linux/chrome$$--incognito$$--user-data-dir=../build/browsers/profile/chromium


### PR DESCRIPTION
The command to launch safari is incorrect. Current methods do not allow users to call safari directly. To open the native install of Safari, the open command is needed