### PR TITLE
Fixed a bug for TooltipControl.js where the tooltip would not render correctly

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/tooltip/TooltipControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/tooltip/TooltipControl.js
@@ -64,7 +64,11 @@ br.presenter.control.tooltip.TooltipControl.prototype.onTooltipMoved = function(
 {
 	if(this.m_oPresentationNode.hasMoved.getValue())
 	{
-		this._addTooltip(this.m_oPresentationNode.message.getValue())
+		//need to delay showing tooltip until view is fully rendered
+		//in case tooltip needs to be shown immediately when page loads
+		setTimeout(function() {
+			this._addTooltip(this.m_oPresentationNode.message.getValue());
+		}.bind(this), 0);
 	}
 	else
 	{


### PR DESCRIPTION
It is expected behaviour that if the element that the tooltip needs to attach itself to is not visible, the tooltip will not render at all.

But if the tooltip needs to visible immediately when the page loads and the parent element is not visible yet, the tooltip will not render.

For that reason, we need to delay execution until rendering is complete

This is easy to test in CT. Please talk to me for a url