### PR TITLE
Removed caplin and caplinx from reserved namespaces and added br inst…

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/AppTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/AppTest.java
@@ -114,8 +114,8 @@ public class AppTest extends SpecTest {
 	@Test
 	public void usingReservedKeywordAsAppNameSpaceThrowsException() throws Exception {
 		given(appTemplate).containsFile("some-file.blah");
-		when(app).populate("caplinx", "default");
-		then(exceptions).verifyException(InvalidRootPackageNameException.class, app.dir(), unquoted("'caplinx'"));
+		when(app).populate("br", "default");
+		then(exceptions).verifyException(InvalidRootPackageNameException.class, app.dir(), unquoted("'br'"));
 	}
 	
 	@Test

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/jslib/JsLibTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/jslib/JsLibTest.java
@@ -51,8 +51,8 @@ public class JsLibTest extends SpecTest {
 	
 	@Test
 	public void populateFailsIfTheLibraryNamespaceIsReserved() throws Exception {
-		when(lib).populate("caplin", "default");
-		then(exceptions).verifyException(InvalidRootPackageNameException.class, "caplin", lib.dir().getPath());
+		when(lib).populate("br", "default");
+		then(exceptions).verifyException(InvalidRootPackageNameException.class, "br", lib.dir().getPath());
 	}
 	
 	@Test

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/NameValidator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/NameValidator.java
@@ -10,7 +10,7 @@ import org.bladerunnerjs.model.engine.Node;
 
 public class NameValidator
 {
-	private static final String[] RESERVED_NAMESPACES = new String[] { "caplin", "caplinx" };
+	private static final String[] RESERVED_NAMESPACES = new String[] { "br" };
 	private static final String[] RESERVED_JS_KEYWORDS = new String[] { "abstract", "as", "boolean", "break", "byte", "case", "catch", 
 		"char", "class", "continue", "const", "debugger", "default", "delete", "do", "double", "else", "enum", "export", "extends", 
 		"false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", 

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/NameValidatorTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/NameValidatorTest.java
@@ -130,7 +130,7 @@ public class NameValidatorTest
 	@Test
 	public void testReservedNamespace()
 	{
-		assertFalse("1a", NameValidator.isValidRootPackageName("caplin"));
+		assertFalse("1a", NameValidator.isValidRootPackageName("br"));
 		assertTrue("1b", NameValidator.isValidRootPackageName("appns"));
 	}
 	
@@ -148,7 +148,7 @@ public class NameValidatorTest
 	public void testgetReservedNamespaceList()
 	{
 		String[] messageLines = NameValidator.getReservedNamespaces().split("\n");
-		assertEquals(messageLines[0], "Reserved namespace(s): 'caplin', 'caplinx'");
+		assertEquals(messageLines[0], "Reserved namespace(s): 'br'");
 		assertTrue(messageLines[2], messageLines[2].startsWith("Banned Namespaces/JavaScript keywords: 'abstract', 'as', 'boolean', 'break'"));
 	}
 	

--- a/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/model/dialog/validator/AppNamespaceValidator.js
+++ b/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/src/brjs/dashboard/app/model/dialog/validator/AppNamespaceValidator.js
@@ -13,7 +13,7 @@ brjs.dashboard.app.model.dialog.validator.AppNamespaceValidator.prototype.valida
 	{
 		oValidationResult.setResult(false, brjs.dashboard.app.NameValidator.RESERVED_JS_WORD_MESSAGE);
 	}
-	else if((vValue == "caplin") || (vValue == "brjs"))
+	else if((vValue == "brjs") || (vValue == "br"))
 	{
 		oValidationResult.setResult(false, "'" + vValue + "' is a reserved namespace.");
 	}

--- a/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/tests/test-unit/js-test-driver/tests/brjs/dashboard/app/model/validator/AppNamespaceValidatorTest.js
+++ b/brjs-sdk/sdk/system-applications/dashboard/dashboard-bladeset/blades/app/tests/test-unit/js-test-driver/tests/brjs/dashboard/app/model/validator/AppNamespaceValidatorTest.js
@@ -24,13 +24,12 @@ AppNamespaceValidatorTest.prototype.testNamespacesCanOnlyBeLowerCaseAlphanumsWhe
 	assertTrue("2c", this.isValid("a1"));
 };
 
-AppNamespaceValidatorTest.prototype.testCaplinAndbrjsAreReservedNames = function()
+AppNamespaceValidatorTest.prototype.testReservedNames = function()
 {
-	assertFalse("1a", this.isValid("caplin"));
-	assertFalse("1b", this.isValid("brjs"));
+	assertFalse("1a", this.isValid("brjs"));
+	assertFalse("1b", this.isValid("br"));
 	
-	assertTrue("2a", this.isValid("caplinz"));
-	assertTrue("2b", this.isValid("brjsyz"));
+	assertTrue("2a", this.isValid("brjsx"));
 };
 
 AppNamespaceValidatorTest.prototype.testThatEmptyStringIsAValidNamespace = function()

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/CreateAppCommandTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/CreateAppCommandTest.java
@@ -75,8 +75,8 @@ public class CreateAppCommandTest extends SpecTest {
 	@Test
 	public void exceptionIsThrownIfTheAppNamespaceIsNotAValidRootPackageName() throws Exception {
 		given(defaultTemplates).templateGroupCreated();
-		when(brjs).runCommand("create-app", "app", "caplin");
-		then(exceptions).verifyException(InvalidRootPackageNameException.class, "caplin", app.dir().getPath())
+		when(brjs).runCommand("create-app", "app", "br");
+		then(exceptions).verifyException(InvalidRootPackageNameException.class, "br", app.dir().getPath())
 			.whereTopLevelExceptionIs(CommandArgumentsException.class);
 	}
 	


### PR DESCRIPTION
Fixes #1404.

Removed `caplin` and `caplinx` from our reserved namespaces, added `br` instead and modified tests accordingly.