### PR TITLE
Bundle file writing improvements

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/api/spec/engine/FileTestCommander.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/spec/engine/FileTestCommander.java
@@ -4,14 +4,10 @@ import java.io.File;
 
 public class FileTestCommander {
 
-	private SpecTest specTest;
-	private File file;
 	private FileTestBuilder fileTestBuilder;
 	private CommanderChainer commanderChainer;
 	
 	public FileTestCommander(SpecTest specTest, File file) {
-		this.specTest = specTest;
-		this.file = file;
 		fileTestBuilder = new FileTestBuilder(specTest, file);
 		commanderChainer = new CommanderChainer(specTest);
 	}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/FileUtils.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/FileUtils.java
@@ -64,9 +64,11 @@ public class FileUtils {
 			if (child.isDirectory())
 			{
 				deleteDirectoryFromBottomUp(child);
+			} else {
+				child.delete();
 			}
-			dir.delete();
 		}
+		dir.delete();
 	}
 	
 	public static void moveDirectoryContents(BRJS brjs, File srcDir, File destDir) throws IOException {

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.BRJS;
-import org.bladerunnerjs.api.logging.Logger;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 import org.bladerunnerjs.api.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.api.model.exception.request.MalformedRequestException;
@@ -58,7 +57,7 @@ public class BundlerHandler
 		
 		String modelRequestPath = getModelRequestPath(bundlePath);
 		
-		repeatedlyAttemptToCreateBundleFile(brjs, bundleFile);
+		createBundleFile(brjs, bundleFile);
 		
 		try (OutputStream bundleFileOutputStream = new FileOutputStream(bundleFile, false);
 			ResponseContent content = BundleSetRequestHandler.handle(new JsTestDriverBundleSet(bundlableNode.getBundleSet()), modelRequestPath, new StaticContentAccessor(app), version); )
@@ -71,29 +70,17 @@ public class BundlerHandler
 	
 	// this is a workaround for the scenario where Windows indexing service or virus scanners etc can lock the file when we try to create it
 	// see http://stackoverflow.com/a/10516563/2634854 for more info
-	private void repeatedlyAttemptToCreateBundleFile(BRJS brjs, File bundleFile) throws IOException
+	private void createBundleFile(BRJS brjs, File bundleFile) throws IOException
 	{
 		if (bundleFile.exists()) {
 			throw new IOException( String.format("The bundle file '%s' already exists and should not. It should have previously been deleted so new content can be written to it", bundleFile.getAbsolutePath()) );
 		}
 		bundleFile.getParentFile().mkdirs();
+		bundleFile.createNewFile();
 		
-		Logger logger = brjs.logger(this.getClass());
-		for (int i = 0; i < 100; i++) {
-			try {
-				if (i % 10 == 0) { // print log line every 10 iterations
-					logger.debug("Attempting to create an empty bundle file at '%s'.", bundleFile.getAbsolutePath());
-				}
-    			bundleFile.createNewFile();
-    			if (bundleFile.isFile()) {
-    				return;
-    			}
-    			Thread.sleep(100);
-			} catch (IOException | InterruptedException ex) {
-				// ignore the exception from creating the file or thread interupted
-			}
+		if (!bundleFile.isFile()) {
+			throw new IOException("Unable to create an empty bundle file at " + bundleFile.getAbsolutePath());
 		}
-		throw new IOException("Unable to create an empty bundle file at " + bundleFile.getAbsolutePath());
 	}
 
 

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
@@ -72,7 +72,7 @@ public class BundlerHandler
 	private void repeatedlyAttemptToCreateBundleFile(File bundleFile) throws IOException
 	{
 		if (bundleFile.exists()) {
-			throw new IOException( String.format("The bundle file '%s' already exists and should have previously been deleted so new content can be written to it", bundleFile.getAbsolutePath()) );
+			throw new IOException( String.format("The bundle file '%s' already exists and should not. It should have previously been deleted so new content can be written to it", bundleFile.getAbsolutePath()) );
 		}
 		bundleFile.getParentFile().mkdirs();
 		for (int i = 0; i < 100; i++) {

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
@@ -9,6 +9,8 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.api.App;
+import org.bladerunnerjs.api.BRJS;
+import org.bladerunnerjs.api.logging.Logger;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 import org.bladerunnerjs.api.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.api.model.exception.request.MalformedRequestException;
@@ -47,7 +49,7 @@ public class BundlerHandler
 	}
 
 	
-	public void createBundleFile(File bundleFile, String bundlePath, String version) throws IOException, MalformedRequestException, ResourceNotFoundException, ContentProcessingException, ModelOperationException
+	public void createBundleFile(BRJS brjs, File bundleFile, String bundlePath, String version) throws IOException, MalformedRequestException, ResourceNotFoundException, ContentProcessingException, ModelOperationException
 	{
 		if (bundlePath.contains("\\"))
 		{
@@ -56,7 +58,7 @@ public class BundlerHandler
 		
 		String modelRequestPath = getModelRequestPath(bundlePath);
 		
-		repeatedlyAttemptToCreateBundleFile(bundleFile);
+		repeatedlyAttemptToCreateBundleFile(brjs, bundleFile);
 		
 		try (OutputStream bundleFileOutputStream = new FileOutputStream(bundleFile, false);
 			ResponseContent content = BundleSetRequestHandler.handle(new JsTestDriverBundleSet(bundlableNode.getBundleSet()), modelRequestPath, new StaticContentAccessor(app), version); )
@@ -69,19 +71,24 @@ public class BundlerHandler
 	
 	// this is a workaround for the scenario where Windows indexing service or virus scanners etc can lock the file when we try to create it
 	// see http://stackoverflow.com/a/10516563/2634854 for more info
-	private void repeatedlyAttemptToCreateBundleFile(File bundleFile) throws IOException
+	private void repeatedlyAttemptToCreateBundleFile(BRJS brjs, File bundleFile) throws IOException
 	{
 		if (bundleFile.exists()) {
 			throw new IOException( String.format("The bundle file '%s' already exists and should not. It should have previously been deleted so new content can be written to it", bundleFile.getAbsolutePath()) );
 		}
 		bundleFile.getParentFile().mkdirs();
+		
+		Logger logger = brjs.logger(this.getClass());
 		for (int i = 0; i < 100; i++) {
 			try {
+				if (i % 10 == 0) { // print log line every 10 iterations
+					logger.debug("Attempting to create an empty bundle file at '%s'.", bundleFile.getAbsolutePath());
+				}
     			bundleFile.createNewFile();
     			if (bundleFile.isFile()) {
     				return;
     			}
-    			Thread.sleep(10);
+    			Thread.sleep(100);
 			} catch (IOException | InterruptedException ex) {
 				// ignore the exception from creating the file or thread interupted
 			}

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/BundlerHandler.java
@@ -71,11 +71,14 @@ public class BundlerHandler
 	// see http://stackoverflow.com/a/10516563/2634854 for more info
 	private void repeatedlyAttemptToCreateBundleFile(File bundleFile) throws IOException
 	{
+		if (bundleFile.exists()) {
+			throw new IOException( String.format("The bundle file '%s' already exists and should have previously been deleted so new content can be written to it", bundleFile.getAbsolutePath()) );
+		}
 		bundleFile.getParentFile().mkdirs();
 		for (int i = 0; i < 100; i++) {
 			try {
-    			boolean fileCreated = bundleFile.createNewFile();
-    			if (fileCreated) {
+    			bundleFile.createNewFile();
+    			if (bundleFile.isFile()) {
     				return;
     			}
     			Thread.sleep(10);

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
@@ -38,9 +38,7 @@ public class JsTestDriverBundleCreator
 	{
 		logger = brjs.logger(JsTestDriverBundleCreator.class);
 		File bundlesDir = new File(jsTestDriverConf.getParentFile(), BUNDLES_DIR_NAME);
-		FileUtils.deleteDirectoryFromBottomUp(bundlesDir);
-		FileUtils.deleteQuietly(brjs, bundlesDir);
-		bundlesDir.mkdir();
+		recreateBundlesDir(brjs, bundlesDir);
 		
 		Map<String, Object> configMap = getMapFromYamlConfig(jsTestDriverConf);
 		
@@ -66,6 +64,20 @@ public class JsTestDriverBundleCreator
 		}
 		MemoizedFile testsDir = jsTestDriverConf.getParentFile().file("tests");
 		checkTestsForIife(brjs, testsDir, testsDir);
+	}
+
+	private static void recreateBundlesDir(BRJS brjs, File bundlesDir) throws IOException
+	{
+		FileUtils.deleteDirectoryFromBottomUp(bundlesDir);
+		if (bundlesDir.exists()) {
+			throw new IOException( String.format("Unable to delete the temporary '%s' directory at %s", bundlesDir.getName(), bundlesDir.getParentFile().getAbsolutePath()) );
+		}
+		
+		bundlesDir.mkdir();
+		if (!bundlesDir.isDirectory()) {
+			throw new IOException( String.format("The '%s' directory does not exist at %s as BRJS was unable to create it", bundlesDir.getName(), bundlesDir.getParentFile().getAbsolutePath()) );
+		}
+		brjs.getFileModificationRegistry().incrementAllFileVersions();
 	}
 
 	private static void checkTestsForIife(BRJS brjs, MemoizedFile rootTestDir, MemoizedFile testsDir) throws IOException

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
@@ -59,7 +59,7 @@ public class JsTestDriverBundleCreator
 			{
 				String bundlePath = StringUtils.substringAfterLast( requestedFile.getAbsolutePath(), BUNDLES_DIR_NAME+File.separator);
 				bundlePath = StringUtils.replace(bundlePath, "\\", "/");
-				bundlerHandler.createBundleFile(requestedFile, bundlePath, brjs.getAppVersionGenerator().getVersion());
+				bundlerHandler.createBundleFile(brjs, requestedFile, bundlePath, brjs.getAppVersionGenerator().getVersion());
 			}
 		}
 		MemoizedFile testsDir = jsTestDriverConf.getParentFile().file("tests");

--- a/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/specutility/BundlerHandlerSpecTest.java
+++ b/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/specutility/BundlerHandlerSpecTest.java
@@ -42,7 +42,7 @@ public class BundlerHandlerSpecTest extends SpecTest
     			File bundleFile = testPack.file(requestPath);
     			String bundlePath = StringUtils.substringAfterLast(bundleFile.getAbsolutePath(), JsTestDriverBundleCreator.BUNDLES_DIR_NAME + File.separator);
     			bundlePath = StringUtils.replace(bundlePath, "\\", "/");
-    			new BundlerHandler(testPack).createBundleFile(bundleFile, bundlePath, brjs.getAppVersionGenerator().getVersion());
+    			new BundlerHandler(testPack).createBundleFile(brjs, bundleFile, bundlePath, brjs.getAppVersionGenerator().getVersion());
 			}
 		}
 	}


### PR DESCRIPTION
Fixes for #1426
- the bundle file delete code will now longer fail silently
- increasing the retry sleep time to 100ms so we try for longer
- using `bundleFile.isFile()` to check if the file has been created rather than incorrectly using the return code from `createNewFile()`

<!---
@huboard:{"order":1427.0,"milestone_order":1427,"custom_state":""}
-->
