### PR TITLE
Added quiet flag for all commands only to show error log messages.

### DIFF
--- a/brjs-runner/src/main/java/org/bladerunnerjs/runner/CommandRunner.java
+++ b/brjs-runner/src/main/java/org/bladerunnerjs/runner/CommandRunner.java
@@ -50,6 +50,7 @@ public class CommandRunner {
 	
 	static {
 		try {
+			argsParser.registerParameter(new Switch("quiet").setShortFlag('q').setLongFlag("quiet").setDefault("false").setHelp("quiet level logging"));
 			argsParser.registerParameter(new Switch("info").setShortFlag('i').setLongFlag("info").setDefault("false").setHelp("info level logging"));
 			argsParser.registerParameter(new Switch("debug").setShortFlag('d').setLongFlag("debug").setDefault("false").setHelp("debug level logging"));
 			argsParser.registerParameter(new FlaggedOption("pkg").setLongFlag("pkg").setHelp("the comma delimited list of packages to show messages from, or '"+
@@ -90,6 +91,7 @@ public class CommandRunner {
 		
 		return byteStreamOutputStream.toString().trim();
 	}
+	
 	public int run(File workingDir, String[] args) throws CommandArgumentsException, CommandOperationException, InvalidNameException, ModelUpdateException, IOException {
 		AbstractRootNode.allowInvalidRootDirectories = false;
 		BRJS brjs = null;
@@ -175,11 +177,15 @@ public class CommandRunner {
 	}
 	
 	private void processedParsedArgs(JSAPResult parsedArgs) {
+		boolean isQuiet = parsedArgs.getBoolean("quiet");
 		boolean isInfo = parsedArgs.getBoolean("info");
 		boolean isDebug = parsedArgs.getBoolean("debug");
 		List<String> whitelistedPackages = (parsedArgs.getString("pkg") != null) ? Arrays.asList(parsedArgs.getString("pkg").split("\\s*,\\s*")) : new ArrayList<String>();
 		boolean logClassNames = parsedArgs.getBoolean("show-pkg");
 		
+		if(isQuiet) {
+			getLoggerStore().setLogLevel(LogLevel.ERROR);
+		}
 		if(isDebug) {
 			getLoggerStore().setLogLevel(LogLevel.DEBUG);
 		}

--- a/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
+++ b/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
@@ -139,6 +139,19 @@ public class CommandRunnerTest {
 	}
 	
 	@Test
+	public void onlyErrorsAreDisplayedWhenTheQuietFlagIsEnabled() throws Exception {
+		dirFile("valid-sdk-directory/conf/templates/default/brjs").mkdirs();
+		dirFile("valid-sdk-directory/sdk").mkdirs();
+		commandRunner.run(new String[] {dir("valid-sdk-directory"), "external-log-test", "--quiet"});
+		
+		String output = outputStream.toString("UTF-8");
+		assertDoesNotContain("warn-level", output);
+		assertDoesNotContain("console-level", output);
+		assertDoesNotContain("info-level", output);
+		assertDoesNotContain("debug-level", output);
+	}
+	
+	@Test
 	public void externalCommandsCanHaveTheirLoggingEnabled() throws Exception {
 		dirFile("valid-sdk-directory/conf/templates/default/brjs").mkdirs();
 		dirFile("valid-sdk-directory/sdk").mkdirs();

--- a/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
+++ b/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
@@ -149,6 +149,7 @@ public class CommandRunnerTest {
 		commandRunner.run(new String[] {dir("valid-sdk-directory"), "external-log-test", "--quiet"});
 		
 		String output = outputStream.toString("UTF-8");
+		assertContains("error-level", output);
 		assertDoesNotContain("warn-level", output);
 		assertDoesNotContain("console-level", output);
 		assertDoesNotContain("info-level", output);

--- a/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
+++ b/brjs-runner/src/test/java/org/bladerunnerjs/runner/CommandRunnerTest.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.api.BRJS;
 import org.bladerunnerjs.api.model.exception.command.CommandOperationException;
 import org.bladerunnerjs.api.plugin.EventObserver;
+import org.bladerunnerjs.logger.ConsoleLoggerStore;
+import org.bladerunnerjs.logger.LogLevel;
 import org.bladerunnerjs.model.ThreadSafeStaticBRJSAccessor;
 import org.bladerunnerjs.model.events.BundleSetCreatedEvent;
 import org.bladerunnerjs.model.events.NewInstallEvent;
@@ -40,7 +42,9 @@ public class CommandRunnerTest {
 	
 	@Before
 	public void setUp() throws Exception {
-		StaticLoggerBinder.getSingleton().getLoggerFactory().setOutputStreams(new PrintStream(outputStream), new PrintStream(errorStream));
+		ConsoleLoggerStore loggerFactory = StaticLoggerBinder.getSingleton().getLoggerFactory();
+		loggerFactory.setOutputStreams(new PrintStream(outputStream), new PrintStream(errorStream));
+		loggerFactory.setLogLevel(LogLevel.WARN);
 		commandRunner = new CommandRunner();
 		
 		tempDir = FileUtils.createTemporaryDirectory( getClass() );


### PR DESCRIPTION
Fixes issue #1409.

Added quiet flag for all commands, using `CommandRunner`, only to show error log messages.

<!---
@huboard:{"order":1307.0,"milestone_order":1433,"custom_state":""}
-->
