### PR TITLE
Added RuntimeException if there is an old test folder parallel to tes…

### DIFF
--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreator.java
@@ -43,6 +43,11 @@ public class JsTestDriverBundleCreator
 		Map<String, Object> configMap = getMapFromYamlConfig(jsTestDriverConf);
 		
 		File baseDirectory = getBaseDirectory(jsTestDriverConf, configMap);
+		File oldTestsDir = new File(baseDirectory.getParentFile(), "tests");
+		
+		if (oldTestsDir.isDirectory()) {
+			throw new RuntimeException("Your folder '" + oldTestsDir.getAbsolutePath() + "' may be an old test location. Please remove it and run your tests again.");
+		}
 		
 		brjs.getFileModificationRegistry().incrementAllFileVersions();
 		TestPack testPack = brjs.locateAncestorNodeOfClass(jsTestDriverConf, TestPack.class);

--- a/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreatorTest.java
+++ b/brjs-legacy/src/test/java/org/bladerunnerjs/legacy/command/test/testrunner/JsTestDriverBundleCreatorTest.java
@@ -48,6 +48,17 @@ public class JsTestDriverBundleCreatorTest {
 		logMessageStore.enableLogging();
 	}
 	
+	@Test(expected=RuntimeException.class)
+	public void throwExceptionIfThereIsAnOldTestsDirNextToTestsUnitDir() throws FileNotFoundException, YamlException, MalformedRequestException, ResourceNotFoundException, ContentProcessingException, IOException, ModelOperationException {
+		// given
+		FileUtils.writeStringToFile(aspectTestConfig, "basepath: .", "UTF-8");		
+		FileUtils.writeStringToFile(aspectTest, "var foo = function(){ /* code */ }", "UTF-8");
+		FileUtils.forceMkdir(new File(brjs.app("app1").aspect("default").dir(), "tests"));
+		
+		// when
+		JsTestDriverBundleCreator.createRequiredBundles(brjs, memoizedConfigFile);
+	}
+	
 	@Test
 	public void logAWarningWhenCommonJsTestsAreNotWrappedWithinAnIIFE() throws FileNotFoundException, YamlException, MalformedRequestException, ResourceNotFoundException, ContentProcessingException, IOException, ModelOperationException {
 		// given


### PR DESCRIPTION
…t-unit or test-acceptance.

I have added a RuntimeException that is being through if there is a folder called `tests` next to the folder containing the test suite we are currently running.

Fixes issue #1302.