### PR TITLE
allowing parsers to be removed from EditableProperty

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/property/EditableProperty.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/property/EditableProperty.js
@@ -4,21 +4,21 @@
 
 /**
  * Constructs a new <code>EditableProperty</code> instance.
- * 
+ *
  * @class
  * @alias module:br/presenter/property/EditableProperty
  * @extends module:br/presenter/property/WritableProperty
  * @implements module:br/presenter/validator/ValidationResultListener
- * 
+ *
  * @classdesc
  * <code>EditableProperty</code> is identical to {@link module:br/presenter/property/WritableProperty},
  * except that it also has the ability to be edited by users.
- * 
+ *
  * <p>Because editable properties can be displayed using controls that allow unconstrained input (e.g
  * text input boxes), {@link #addValidator} can be used to add validators that provide user feedback
  * when invalid values are entered, and {@link #addParser} can be used to help convert user input into
  * valid forms.</p>
- * 
+ *
  * @param {Object} vValue (optional) The default value for this property.
  */
 br.presenter.property.EditableProperty = function(vValue)
@@ -53,14 +53,14 @@ br.Core.implement(br.presenter.property.EditableProperty, br.presenter.validator
 /**
  * Adds a {@link module:br/presenter/parser/Parser} that will be run each time the user enters a
  * new value.
- * 
+ *
  * <p>Parsers allow user input to be normalized prior to validation. For example, the
  * user may be allowed to enter '1M' into an amount field, and a parser might convert
  * this to '1000000' before it is validated by a numeric validator.</p>
- * 
+ *
  * <p>Any number of parsers can be added to an editable property, and will be applied
  * in the same way that production rules are applied in production rule systems:</p>
- * 
+ *
  * <ol>
  *   <li>The parsers will be iterated one by one in the same order in which they were
  *	added.</li>
@@ -69,10 +69,10 @@ br.Core.implement(br.presenter.property.EditableProperty, br.presenter.validator
  *   <li>Once a clean run through all the parsers is achieved (with none of them
  *	available to produce new input) the parsing phase is complete.</li>
  * </ol>
- * 
+ *
  * <p>By configuring a number of simple parsers in the same way as production
  * rules are used, complex input handling can be supported.</p>
- * 
+ *
  * @param {module:br/presenter/parser/Parser} oParser the {@link module:br/presenter/parser/Parser} being added.
  * @param {Object} mConfig (optional) Any additional configuration for the parser.
  * @type br.presenter.property.EditableProperty
@@ -90,9 +90,25 @@ br.presenter.property.EditableProperty.prototype.addParser = function(oParser, m
 };
 
 /**
+* Removes {@link module:br/presenter/parser/Parser} from parsers array.
+*
+* @param {Object} parser - The parser to remove.
+* @returns {boolean} - true if any validator was removed
+*/
+br.presenter.property.EditableProperty.prototype.removeParser = function (parser) {
+	for (var i = 0, l = this.m_pParsers.length; i < l; ++i) {
+		if (this.m_pParsers[i].parser === parser) {
+			this.m_pParsers.splice(i, 1);
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
  * Adds a {@link module:br/presenter/validator/Validator} that will be run each time the user enters a
  * new value.
- * 
+ *
  * <p>Validators allow users to be immediately informed when any of their input is
  * invalid. The {@link module:br/presenter/node/Field},
  * {@link module:br/presenter/node/SelectionField} and
@@ -100,7 +116,7 @@ br.presenter.property.EditableProperty.prototype.addParser = function(oParser, m
  * validation call-backs on {@link module:br/presenter/property/PropertyListener} and
  * maintain <code>hasError</code> and <code>failureMessage</code> properties that can
  * be displayed within the view.</p>
- * 
+ *
  * @param {module:br/presenter/validator/Validator} oValidator the {@link module:br/presenter/validator/Validator} being added.
  * @param {Object} mConfig (optional) Any additional configuration for the validator.
  * @param {Object} mValidatorInfo (optional) Information about the validator gets written here.
@@ -159,21 +175,21 @@ br.presenter.property.EditableProperty.prototype.addListener = function(oListene
 /**
  * A convenience method that allows <em>validation error</em> listeners to be added for objects that do
  * not themselves implement {@link module:br/presenter/property/PropertyListener}.
- * 
+ *
  * <p>Listeners added using <code>addValidationErrorListener()</code> will only be
  * notified when {@link module:br/presenter/property/PropertyListener#onValidationError}
  * fires, and will not be notified if any of the other
  * {@link module:br/presenter/property/PropertyListener} call-backs fire. The advantage to
  * using this method is that objects can choose to listen to call-back events on
  * multiple properties.</p>
- * 
+ *
  * <p>The invoked method will be passed two arguments:</p>
- * 
+ *
  * <ul>
  *   <li><code>vPropertyValue</code> &mdash; The current value of the property.</li>
  *   <li><code>sErrorMessage</code> &mdash; The failure message.</li>
  * </ul>
- * 
+ *
  * @param {Object} oListener The listener to be added.
  * @param {String} sMethod The name of the method on the listener that will be invoked each time there is a validation error.
  * @param {boolean} bNotifyImmediately (optional) Whether to invoke the listener immediately for the current value.
@@ -190,7 +206,7 @@ br.presenter.property.EditableProperty.prototype.addValidationErrorListener = fu
 /**
  * A convenience method that allows <em>validation success</em> listeners to be added for objects that do
  * not themselves implement {@link module:br/presenter/property/PropertyListener}.
- * 
+ *
  * <p>Listeners added using <code>addValidationSuccessListener()</code> will only be
  * notified when {@link module:br/presenter/property/PropertyListener#onValidationSuccess}
  * fires, and will not be notified if any of the other
@@ -214,7 +230,7 @@ br.presenter.property.EditableProperty.prototype.addValidationSuccessListener = 
 /**
  * A convenience method that allows <em>validation complete</em> listeners to be added for objects that do
  * not themselves implement {@link module:br/presenter/property/PropertyListener}.
- * 
+ *
  * <p>Listeners added using <code>addValidationCompleteListener()</code> will only be
  * notified when {@link module:br/presenter/property/PropertyListener#onValidationComplete}
  * fires, and will not be notified if any of the other
@@ -238,10 +254,10 @@ br.presenter.property.EditableProperty.prototype.addValidationCompleteListener =
 /**
  * Sets the unformatted value for this property and notifies listeners of the
  * change.
- * 
+ *
  * <p>This method is the same as {@link module:br/presenter/property/WritableProperty#setValue},
  * except that validation will also be performed.</p>
- * @param {Variant} vValue The value to set. 
+ * @param {Variant} vValue The value to set.
  * @see br.presenter.property.WritableProperty#setValue
  */
 br.presenter.property.EditableProperty.prototype.setValue = function(vValue)
@@ -255,7 +271,7 @@ br.presenter.property.EditableProperty.prototype.setValue = function(vValue)
 
 /**
  * Accepts a user entered value that may need to be parsed before calling {@link #setValue}.
- * 
+ *
  * @param {Object} vUserEnteredValue The unparsed value to set.
  * @type br.presenter.property.EditableProperty
  */
@@ -268,7 +284,7 @@ br.presenter.property.EditableProperty.prototype.setUserEnteredValue = function(
 
 /**
  * Force the property to be re-validated.
- * 
+ *
  * <p>This method is useful for code that wishes to perform cross-property validation &mdash; it is
  * used by the {@link module:br/presenter/validator/CrossValidationPropertyBinder} class for
  * example.</p>
@@ -311,13 +327,13 @@ br.presenter.property.EditableProperty.prototype.forceValidation = function()
 
 
 /**
- * This method provides a synchronous way of checking the validation state. 
- * 
+ * This method provides a synchronous way of checking the validation state.
+ *
  */
 br.presenter.property.EditableProperty.prototype.hasValidationError = function()
-{ 
-	var vValue = this.getValue(); 
-	return this._hasValidationError(vValue); 
+{
+	var vValue = this.getValue();
+	return this._hasValidationError(vValue);
 };
 
 /**
@@ -327,12 +343,12 @@ br.presenter.property.EditableProperty.prototype._hasValidationError = function(
 {
 	for(var key in this.m_mValidators) {
 		var oValidator = this.m_mValidators[key];
-		var oValidationResult = new br.presenter.validator.ValidationResult(); 
-		oValidator.validator.validate(vValue, oValidator.config, oValidationResult); 
-		if (!oValidationResult.isValid()) return true; 
-	} 
-	return false; 
-}; 
+		var oValidationResult = new br.presenter.validator.ValidationResult();
+		oValidator.validator.validate(vValue, oValidator.config, oValidationResult);
+		if (!oValidationResult.isValid()) return true;
+	}
+	return false;
+};
 
 
 // *********************** ValidationResultListener Interface ***********************

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/property/EditablePropertyTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/property/EditablePropertyTest.js
@@ -14,7 +14,7 @@ EditablePropertyTest.prototype.tearDown = function()
 };
 
 EditablePropertyTest.prototype._getTestValidator = function(bAsync)
-{	
+{
 	var fValidator = function(bAsync)
 	{
 		this.m_bAsync = (bAsync === true);
@@ -600,3 +600,31 @@ EditablePropertyTest.prototype.test_hasValidationErrorReturnsFalseIfAllValidator
 	assertFalse(oEditableProperty.hasValidationError());
 };
 
+EditablePropertyTest.prototype.test_parsersCanBeRemovedAndReturnTrueOnlyIfTheyAreRemoved = function()
+{
+	var fParser = function(parseOperation) {
+		this.parseOperation = parseOperation;
+	};
+	br.Core.implement(fParser, br.presenter.parser.Parser);
+
+	fParser.prototype.parse = function(sValue, mConfig){
+		return isNaN(sValue) ? null : this.parseOperation(sValue);
+	};
+	fParser.prototype.isSingleUseParser = function(sValue, mConfig){
+		return true;
+	};
+	
+	var oParser1 = new fParser(function(nValue){return nValue / 10});
+	var oParser2 = new fParser(function(nValue){return nValue + "K"});
+	
+	var oEditableProperty = new br.presenter.property.EditableProperty().addParser(oParser1, {}).addParser(oParser2, {});
+	
+	oEditableProperty.setUserEnteredValue("10");
+	assertEquals("1K", oEditableProperty.getValue());
+	
+	assertTrue(oEditableProperty.removeParser(oParser1));
+	oEditableProperty.setUserEnteredValue("10");
+	assertEquals("10K", oEditableProperty.getValue());
+	
+	assertFalse(oEditableProperty.removeParser(oParser1));
+};


### PR DESCRIPTION
- allowing parsers to be removed from EditableProperty
- similar to removeValidator - returns true if a parser was removed, false otherwise.

<!---
@huboard:{"order":1304.0,"milestone_order":1448,"custom_state":""}
-->
