### PR TITLE
allowing nested setTimeouts in TimeUtility

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/TimeUtility.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/TimeUtility.js
@@ -10,7 +10,7 @@ var Errors = require('br/Errors');
  * @private
  * @class
  * @alias module:br/test/TimeUtility
- * 
+ *
  * @classdesc
  * Utility class containing static methods that can be useful for controlling time in tests.
  */
@@ -89,7 +89,7 @@ TimeUtility.clearCapturedFunctions = function() {
  *  is passed, this will execute all captured functions.
  */
 TimeUtility.executeCapturedFunctions = function(nMsToExecuteTo) {
-	var capturedFunction;
+	var capturedFunction, innerCapturedFunction;
 
 	this.pCapturedTimerFunctionArgs.sort(this.fCapturedTimersSort);
 
@@ -97,7 +97,14 @@ TimeUtility.executeCapturedFunctions = function(nMsToExecuteTo) {
 		capturedFunction = this.pCapturedTimerFunctionArgs[idx];
 
 		if (nMsToExecuteTo == null || capturedFunction[1] <= nMsToExecuteTo) {
+			var l = this.pCapturedTimerFunctionArgs.length;
 			capturedFunction[0]();
+			
+			for (var idy = l; idy < this.pCapturedTimerFunctionArgs.length; idy++) {
+				innerCapturedFunction = this.pCapturedTimerFunctionArgs[idy];
+				innerCapturedFunction[1] += capturedFunction[1];
+			}
+			
 			this.pCapturedTimerFunctionArgs.splice(idx, 1);
 			idx--;
 		} else {

--- a/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/TimeUtility.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/TimeUtility.js
@@ -97,10 +97,10 @@ TimeUtility.executeCapturedFunctions = function(nMsToExecuteTo) {
 		capturedFunction = this.pCapturedTimerFunctionArgs[idx];
 
 		if (nMsToExecuteTo == null || capturedFunction[1] <= nMsToExecuteTo) {
-			var l = this.pCapturedTimerFunctionArgs.length;
+			var timerArgsLength = this.pCapturedTimerFunctionArgs.length;
 			capturedFunction[0]();
 			
-			for (var idy = l; idy < this.pCapturedTimerFunctionArgs.length; idy++) {
+			for (var idy = timerArgsLength; idy < this.pCapturedTimerFunctionArgs.length; idy++) {
 				innerCapturedFunction = this.pCapturedTimerFunctionArgs[idy];
 				innerCapturedFunction[1] += capturedFunction[1];
 			}

--- a/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/testing/TimeUtilityTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/test-unit/tests/br/testing/TimeUtilityTest.js
@@ -188,3 +188,56 @@ TimeUtilityTest.prototype["test that subsequent calls to executeCapturedFunction
 	assertTrue(bSecondTimeoutExecuted);
 	assertTrue(bThirdTimeoutExecuted);
 };
+
+TimeUtilityTest.prototype["test that timeouts can contain timeouts"] = function() {
+	br.test.TimeUtility.captureTimerFunctions();
+	var bOuterTimeoutExecuted = false;
+	var bNestedTimeoutExecuted = false;
+	var bSecondOuterTimeoutExecuted = false;
+
+	window.setTimeout(function(){
+		bOuterTimeoutExecuted = true;
+		window.setTimeout(function(){ bNestedTimeoutExecuted = true; }, 10);
+	}, 10);
+	window.setTimeout(function(){ bSecondOuterTimeoutExecuted = true; }, 20);
+	
+	br.test.TimeUtility.executeCapturedFunctions(10);
+	
+	assertTrue(bOuterTimeoutExecuted);
+	assertFalse(bNestedTimeoutExecuted);
+	assertFalse(bSecondOuterTimeoutExecuted);
+	
+	br.test.TimeUtility.executeCapturedFunctions(10);
+
+	assertTrue(bOuterTimeoutExecuted);
+	assertTrue(bNestedTimeoutExecuted);
+	assertTrue(bSecondOuterTimeoutExecuted);
+};
+
+TimeUtilityTest.prototype["test that timeouts can contain an arbitrary amount of nested timeouts"] = function() {
+	br.test.TimeUtility.captureTimerFunctions();
+	var bTimeout1Executed = false;
+	var bTimeout2Executed = false;
+	var bTimeout3Executed = false;
+	var bTimeout4Executed = false;
+
+	window.setTimeout(function(){
+		bTimeout1Executed = true;
+		window.setTimeout(function(){
+			bTimeout2Executed = true;
+			window.setTimeout(function(){
+				bTimeout3Executed = true;
+				window.setTimeout(function(){
+					bTimeout4Executed = true;
+				}, 10);
+			}, 10);
+		}, 10);
+	}, 10);
+	
+	br.test.TimeUtility.executeCapturedFunctions();
+	
+	assertTrue(bTimeout1Executed);
+	assertTrue(bTimeout2Executed);
+	assertTrue(bTimeout3Executed);
+	assertTrue(bTimeout4Executed);
+};


### PR DESCRIPTION
- allowing `setTimeout` functions to contain other `setTimeout` calls when being used with `TimeUtility` test util methods

<!---
@huboard:{"order":1305.0,"milestone_order":1449,"custom_state":""}
-->
