### PR TITLE
Fix for index.jsp tokens not being replaced

### DIFF
--- a/brjs-core-tests/src/test-integration/java/org/bladerunnerjs/spec/brjs/appserver/ServedAppTest.java
+++ b/brjs-core-tests/src/test-integration/java/org/bladerunnerjs/spec/brjs/appserver/ServedAppTest.java
@@ -109,6 +109,18 @@ public class ServedAppTest extends SpecTest
 	}
 	
 	@Test
+	public void tokensInIndexJspAreReplaced() throws Exception
+	{
+		given(app).hasBeenPopulated("default")
+			.and(app).containsFileWithContents("app.conf", "localeCookieName: BRJS.LOCALE\n"
+					+ "locales: en\n"
+					+ "requirePrefix: appns")
+			.and(aspect).containsFileWithContents("index.jsp", "<@tagToken @/>")
+			.and(appServer).started();
+		then(appServer).requestForUrlReturns("/app/", "dev replacement");
+	}
+	
+	@Test
 	public void localeForwarderPageCanBeAccessedWithoutEndingInForwardSlash() throws Exception
 	{
 		given(app).hasBeenPopulated("default")

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/BuildAppTest.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/app/BuildAppTest.java
@@ -8,6 +8,7 @@ import org.bladerunnerjs.api.AppConf;
 import org.bladerunnerjs.api.Aspect;
 import org.bladerunnerjs.api.BladerunnerConf;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
+import org.bladerunnerjs.spec.brjs.appserver.MockTagHandler;
 import org.bladerunnerjs.testing.utility.MockContentPlugin;
 import org.bladerunnerjs.testing.utility.ScriptedContentPlugin;
 import org.bladerunnerjs.testing.utility.ScriptedRequestGeneratingTagHandlerPlugin;
@@ -29,6 +30,7 @@ public class BuildAppTest extends SpecTest {
 		given(brjs).automaticallyFindsBundlerPlugins()
 			.and(brjs).automaticallyFindsMinifierPlugins()
 			.and(brjs).hasContentPlugins(new MockContentPlugin())
+			.and(brjs).hasTagHandlerPlugins(new MockTagHandler("tagToken", "dev replacement", "prod replacement"))
 			.and(brjs).hasBeenCreated();
 			app = brjs.app("app1");
 			appConf = app.appConf();
@@ -88,12 +90,20 @@ public class BuildAppTest extends SpecTest {
 	}
 	
 	@Test
-	public void jspIndexPagesAreUnprocessedAndKeepTheJspSuffix() throws Exception {
+	public void indexJspIndexPagesAreUnprocessedAndKeepTheJspSuffix() throws Exception {
 		given(defaultAspect).containsFileWithContents("index.jsp", "<%= 1 + 2 %>\n<@js.bundle@/>")
 			.and(brjs).localeSwitcherHasContents("")
 			.and(app).hasBeenBuilt(targetDir);
 		then(targetDir).containsFileWithContents("/index.jsp", "<%= 1 + 2 %>")
 			.and(targetDir).containsFileWithContents("/index.jsp", "/js/prod/combined/bundle.js");
+	}
+	
+	@Test
+	public void tokensInIndexJspAreReplaced() throws Exception
+	{
+		given(defaultAspect).containsFileWithContents("index.jsp", "<@tagToken @/>")
+			.and(app).hasBeenBuilt(targetDir);
+		then(targetDir).containsFileWithContents("/index.jsp", "prod replacement");
 	}
 	
 	@Test

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/ServletContentAccessor.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/ServletContentAccessor.java
@@ -50,7 +50,9 @@ public class ServletContentAccessor extends StaticContentAccessor
 			if (urlPath.endsWith(".jsp")) {
 				urlPath = (!urlPath.startsWith("/")) ? "/"+urlPath : urlPath;
 				request.setAttribute(BRJSDevServletFilter.IGNORE_REQUEST_ATTRIBUTE, true);
-    			servletContext.getRequestDispatcher(urlPath).forward(request, response);
+				CharResponseWrapper responseWrapper = new CharResponseWrapper(response);
+    			servletContext.getRequestDispatcher(urlPath).forward(request, responseWrapper);
+    			IOUtils.copy(responseWrapper.getReader(), output);
     		} else {
     			super.writeLocalUrlContentsToOutputStream(urlPath, output);
     		}

--- a/brjs-core/src/main/java/org/bladerunnerjs/appserver/ServletContentAccessor.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/appserver/ServletContentAccessor.java
@@ -30,18 +30,7 @@ public class ServletContentAccessor extends StaticContentAccessor
 	
 	@Override
 	public void writeLocalUrlContentsToOutputStream(String urlPath, OutputStream output) throws IOException {		
-		try {
-			if (urlPath.endsWith(".jsp")) {
-				urlPath = (!urlPath.startsWith("/")) ? "/"+urlPath : urlPath;
-    			CharResponseWrapper responseWrapper = new CharResponseWrapper(response);
-    			servletContext.getRequestDispatcher(urlPath).include(request, responseWrapper);
-    			IOUtils.copy(responseWrapper.getReader(), output);
-    		} else {
-    			super.writeLocalUrlContentsToOutputStream(urlPath, output);
-    		}
-		} catch (ServletException ex) {
-			throw new IOException(ex);
-		}
+		handleRequest(urlPath, output);
 	}
 	
 	@Override

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/UrlContentAccessor.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/UrlContentAccessor.java
@@ -8,14 +8,15 @@ public abstract class UrlContentAccessor
 {
 	
 	/**
-	 * 
 	 * Write the contents of the reply from the given URL to the output stream. 
+	 * @deprecated Use handleRequest(String, OutputStream) instead
 	 */
 	public abstract void writeLocalUrlContentsToOutputStream(String urlPath, OutputStream output) throws IOException;
 	
 	/**
-	 * Attempts to handle the request using the server. If a server context isn't available writes the content of the local url path to the output stream, otherwise
-	 * use the server context directly to handle the request.
+	 * Attempts to handle the request using the server. 
+	 * If a server context isn't available writes the content of the local URL path to the output stream, otherwise
+	 * uses the server context to handle the request and write to the output stream.
 	 */
 	public abstract void handleRequest(String urlPath, OutputStream output) throws IOException;
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/AppRequestHandler.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/AppRequestHandler.java
@@ -186,7 +186,7 @@ public class AppRequestHandler
 			
 			String pathRelativeToApp = app.dir().getRelativePath(indexPage);
 			ByteArrayOutputStream indexPageContent = new ByteArrayOutputStream();
-			contentAccessor.writeLocalUrlContentsToOutputStream(pathRelativeToApp, indexPageContent);
+			contentAccessor.handleRequest(pathRelativeToApp, indexPageContent);
 			
 			return TagPluginUtility.getUsedTagsAndAttributes(indexPageContent.toString(), browsableNode.getBundleSet(), requestMode, locale);
 		}


### PR DESCRIPTION
Fix the bug detailed in https://github.com/BladeRunnerJS/brjs/issues/1450#issuecomment-118378197 where tokens weren't replaced in `index.jsp` pages.