### PR TITLE
An empty string should be returned if the JNDI lookup returns null.

### DIFF
--- a/brjs-servlet/src/main/java/org/bladerunnerjs/appserver/util/JndiTokenFinder.java
+++ b/brjs-servlet/src/main/java/org/bladerunnerjs/appserver/util/JndiTokenFinder.java
@@ -9,7 +9,7 @@ public class JndiTokenFinder
 	private final Context appServerContext;
 
 	public JndiTokenFinder() throws NamingException
-	{		
+	{
 		this.appServerContext = (Context) new InitialContext();
 	}
 
@@ -27,17 +27,16 @@ public class JndiTokenFinder
 
 		try
 		{
-			Object theToken = appServerContext.lookup("java:comp/env/" + tokenName);
-			if (theToken != null)
+			Object tokenValue = appServerContext.lookup("java:comp/env/" + tokenName);
+			if (tokenValue != null)
 			{
-				return theToken.toString();
+				return tokenValue.toString();
 			}
+			return "";
 		}
 		catch (NamingException ex)
 		{
 			return null;
 		}
-		return null;
 	}
-
 }

--- a/brjs-servlet/src/test/java/org/bladerunnerjs/appserver/util/JndiTokenFinderTest.java
+++ b/brjs-servlet/src/test/java/org/bladerunnerjs/appserver/util/JndiTokenFinderTest.java
@@ -61,16 +61,16 @@ public class JndiTokenFinderTest
 	{
 		when(mockContext.lookup("java:comp/env/NON.EXISTANT.TOKEN")).thenThrow(NamingException.class);
 
-		assertNull("token value", tokenFinder.findTokenValue("NON.EXISTANT.TOKEN"));
+		assertNull(tokenFinder.findTokenValue("NON.EXISTANT.TOKEN"));
 		verify(mockContext, times(1)).lookup("java:comp/env/NON.EXISTANT.TOKEN");
 	}
 
 	@Test
-	public void testNullIsReturnedIfLookupReturnsNull() throws Exception
+	public void testEmptyStringIsReturnedIfLookupReturnsNull() throws Exception
 	{
 		when(mockContext.lookup("java:comp/env/NON.EXISTANT.TOKEN")).thenReturn(null);
 
-		assertNull("token value", tokenFinder.findTokenValue("NON.EXISTANT.TOKEN"));
+		assertEquals("", tokenFinder.findTokenValue("NON.EXISTANT.TOKEN"));
 		verify(mockContext, times(1)).lookup("java:comp/env/NON.EXISTANT.TOKEN");
 	}
 


### PR DESCRIPTION
If a JNDI entry is set to an empty string the JNDI service returns null which prevents the use of empty values.