### PR TITLE
upgrading to the new Travis container based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,14 @@ jdk:
 - oraclejdk8
 git:
  depth: 200
+sudo: false
+addons:
+  apt:
+    packages:
+    - libgd2-xpm
+    - ia32-libs
+    - ia32-libs-multiarch
 before_install:
-- echo "foreign-architecture i386" | sudo tee /etc/dpkg/dpkg.cfg.d/multiarch && sudo apt-get update -qq
-- sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch
 - export JAVA7_HOME=/usr/lib/jvm/java-7-oracle
 - export JAVA8_HOME=/usr/lib/jvm/java-8-oracle
 - "export DISPLAY=:99.0"


### PR DESCRIPTION
Changes the Travis config so we're using the new container based infrastructure which is meant to be faster and more reliable - http://docs.travis-ci.com/user/migrating-from-legacy

<!---
@huboard:{"order":735.0,"milestone_order":1484,"custom_state":""}
-->
