### PR TITLE
adding a .gitattributes which should force line endings of brjs scripts

### DIFF
--- a/brjs-sdk/.gitattributes
+++ b/brjs-sdk/.gitattributes
@@ -1,0 +1,2 @@
+brjs		eol=lf
+brjs.md		eol=crlf


### PR DESCRIPTION
adding a .gitattributes which should force brjs to be checked out as lf and brjs.cmd as crlf. Fixes #1441.