### PR TITLE
Make ViewFixture errors more useful

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/ViewFixture.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/ViewFixture.js
@@ -267,7 +267,7 @@ ViewFixture.prototype._getHandler = function(propertyName, value) {
 		if (handler.elements.length === 1) {
 			handler.selectedElement = handler.elements[0];
 		} else {
-			this._verifyOnlyOneElementSelected(handler.elements, handler.property);
+			this._verifyOnlyOneElementSelected(handler.elements, handler.property, propertyName, value);
 		}
 	}
 
@@ -291,11 +291,13 @@ ViewFixture.prototype._getViewElements = function(propertyName) {
 };
 
 /** @private */
-ViewFixture.prototype._verifyOnlyOneElementSelected = function(elements, selector) {
+ViewFixture.prototype._verifyOnlyOneElementSelected = function(elements, selector, propertyName, value) {
 	if (elements.length === 0) {
-		throw 'No view element found for "' + selector + '"';
+		throw 'No view element found for "' + selector + '". Processing property "' + propertyName +
+			'" and looking for value "' + value + '"';
 	} else if (elements.length > 1) {
-		throw 'More than one view element found for "' + selector + '"';
+		throw 'More than one view element found for "' + selector + '". Processing property "' + propertyName +
+			'" and looking for value "' + value + '"';
 	}
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/ViewFixture.js
+++ b/brjs-sdk/sdk/libs/javascript/br-test/src/br/test/ViewFixture.js
@@ -291,13 +291,20 @@ ViewFixture.prototype._getViewElements = function(propertyName) {
 };
 
 /** @private */
-ViewFixture.prototype._verifyOnlyOneElementSelected = function(elements, selector, propertyName, value) {
+ViewFixture.prototype._verifyOnlyOneElementSelected = function(elements, viewHandler, propertyName, value) {
+	var exceptionMessage = '';
 	if (elements.length === 0) {
-		throw 'No view element found for "' + selector + '". Processing property "' + propertyName +
-			'" and looking for value "' + value + '"';
+		exceptionMessage = 'No view element found for "' + viewHandler + '".';
 	} else if (elements.length > 1) {
-		throw 'More than one view element found for "' + selector + '". Processing property "' + propertyName +
-			'" and looking for value "' + value + '"';
+		exceptionMessage = 'More than one view element found for "' + viewHandler + '".';
+	}
+
+	if (exceptionMessage !== '') {
+		if (typeof propertyName !== 'undefined') {
+			exceptionMessage += ' Processing property "' + propertyName + '" and looking for value "' + value + '".';
+		}
+
+		throw exceptionMessage;
 	}
 };
 


### PR DESCRIPTION
Given this line in a test:

```javascript
and("ticket.view.(.my-selector).text = 'XYZ'");
```

if no element was found for `.my-selector`, you would get this error message:

```
No view element found for "text"
```

After this change, you get this:


```
No view element found for "text". Processing property "(.my-selector).text" and looking for value "XYZ"
```

which is obviously much much better as it actually helps you pin point the location in the test where the problem is.

<!---
@huboard:{"order":1515.75,"milestone_order":1513,"custom_state":""}
-->
