### PR TITLE
Don't print spurious characters on Ubuntu

### DIFF
--- a/brjs-sdk/sdk/brjs
+++ b/brjs-sdk/sdk/brjs
@@ -24,7 +24,8 @@ BRJS_CLASSPATH="$SCRIPT_DIR/libs/java/system/*:$SCRIPT_DIR/../conf/java/*"
 uname -a | grep -E "(^CYGWIN|^MINGW32.*Msys$)" > /dev/null
 if [ $? -eq 0 ]; then
 	# Cygwin & newer GitBash versions
-	java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`pwd`" "$@"
+	PWD=`pwd`
+	java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`cygpath -wp $PWD`" "$@"
 else
 	# UNIX & older GitBash versions
 	java $JAVA_OPTS -cp "$BRJS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"

--- a/brjs-sdk/sdk/brjs
+++ b/brjs-sdk/sdk/brjs
@@ -21,8 +21,7 @@ fi
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 BRJS_CLASSPATH="$SCRIPT_DIR/libs/java/system/*:$SCRIPT_DIR/../conf/java/*"
 
-# if using cygwin or the latest versions of gitbash
-uname -a | grep -E "(^CYGWIN|^MINGW32.*MSys$)"
+uname -a | grep -E "(^CYGWIN|^MINGW32.*Msys$)" > /dev/null
 if [ $? -eq 0 ]; then
 	# Cygwin & newer GitBash versions
 	java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`pwd`" "$@"

--- a/brjs-sdk/sdk/brjs
+++ b/brjs-sdk/sdk/brjs
@@ -22,10 +22,11 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 BRJS_CLASSPATH="$SCRIPT_DIR/libs/java/system/*:$SCRIPT_DIR/../conf/java/*"
 
 # if using cygwin or the latest versions of gitbash
-if [[ "$(echo $(uname -s) | cut -c 1-6)" = "CYGWIN" || "$(uname -a)" = *"Msys"* ]]; then
-	# Cygwin version
+uname -a | grep -E "(^CYGWIN|^MINGW32.*MSys$)"
+if [ $? -eq 0 ]; then
+	# Cygwin & newer GitBash versions
 	java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`pwd`" "$@"
 else
-	# UNIX & GitBash version
+	# UNIX & older GitBash versions
 	java $JAVA_OPTS -cp "$BRJS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"
 fi


### PR DESCRIPTION
Because `bin/sh` points to `bin/dash` rather than `bin/bash` on Ubuntu,
we can't use double square bracket notation, so use `grep` instead.

<!---
@huboard:{"order":1527.0,"milestone_order":1528,"custom_state":""}
-->
