### PR TITLE
allow access to .dat files during test to fix java8u60 eclipse tests

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/IO.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/IO.java
@@ -11,10 +11,10 @@ import org.apache.commons.io.filefilter.SuffixFileFilter;
 public class IO {
 	private final Map<FileAccessLimitScope, File[]> activeScopes = new LinkedHashMap<>();
 	private final SecurityManager securityManager;
-	private final IOFileFilter classFileAndJarFileFilter = new SuffixFileFilter( new String[] { ".class", ".jar" } );
+	private final IOFileFilter jvmCoreFileFilter = new SuffixFileFilter( new String[] { ".class", ".jar", ".dat" } );
 	
 	public IO(IOFileFilter globalFileFilter) {
-		securityManager = new BRJSSecurityManager( new OrFileFilter(classFileAndJarFileFilter, globalFileFilter), activeScopes);
+		securityManager = new BRJSSecurityManager( new OrFileFilter(jvmCoreFileFilter, globalFileFilter), activeScopes);
 	}
 	
 	public FileAccessLimitScope limitAccessToWithin(String scopeIdentifier, File[] watchItems) {


### PR DESCRIPTION
Tests fail in Eclipse after an upgrade to Java8u60 - because access to a timezone data file was being blocked and we got a `NoClassDefFoundError("Could not initialize class sun.util.calendar.ZoneInfoFile")
`. This PR adds `.dat` files to the list that we won't block access to during tests.

*This might also fix the issues we've been seeing in Jenkins since its a similar exception message*