### PR TITLE
Bugfix jquery auto complete box blur in ie8

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/selectionfield/JQueryAutoCompleteControl.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/control/selectionfield/JQueryAutoCompleteControl.js
@@ -115,7 +115,9 @@ JQueryAutoCompleteControl.prototype.onViewReady = function() {
 			event.preventDefault();
 			// if the selection is triggered by a click, not by pressing enter, then blur
 			if (self.m_bBlurAfterClick === true) {
-				if (event.which === 1) {
+				var ie8LeftClick = !event.button && !event.which;
+
+				if (event.which === 1 || ie8LeftClick) {
 					this.blur();
 				}
 			}


### PR DESCRIPTION
JqueryAutoCompleteBox BlurAfterClick option not working on IE8

<!---
@huboard:{"order":1559.0,"milestone_order":1559,"custom_state":""}
-->
