### PR TITLE
Hide view namespace knockout 897

### DIFF
--- a/brjs-sdk/sdk/templates/default/blade/src/@bladeTitleBlade.js
+++ b/brjs-sdk/sdk/templates/default/blade/src/@bladeTitleBlade.js
@@ -1,0 +1,14 @@
+var KnockoutComponent = require('br/knockout/KnockoutComponent')
+
+var @bladeTitleBlade = function() {
+	
+}
+
+@bladeTitleBlade.prototype.getComponent = function() {
+	var @bladeTitleViewModel = require( '@bladeRequirePrefix/@bladeTitleViewModel' )
+	var @bladeTitleModel = new @bladeTitleViewModel();
+	var @bladeTitleComponent = new KnockoutComponent( '@bladeNamespace.view-template', @bladeTitleModel );
+	return @bladeTitleComponent;
+}
+
+module.exports = bladeTitleBlade;

--- a/brjs-sdk/sdk/templates/default/bladesetworkbench/index.html
+++ b/brjs-sdk/sdk/templates/default/bladesetworkbench/index.html
@@ -53,14 +53,10 @@
 			var workbench = new Workbench(250, 310);
 			addEventHubLogger( workbench );
 
-			// ViewModel that is being created in the workbench
-			/*var myBladeTitleViewModel = require( 'myBladeRequirePrefix/myBladeTitleViewModel' );
-			var KnockoutComponent = require( 'br/knockout/KnockoutComponent' );
-
-			var model = new myBladeTitleViewModel();
-			var component = new KnockoutComponent( 'myBladeNamespace.view-template', model );
-
-			addComponent( component, workbench )
+			// Add Blade component to workbench
+			/*var myBladeTitleBlade = require( 'myBladeRequirePrefix/myBladeTitleBlade' );
+			
+			addComponent( new myBladeTitleBlade().getComponent(), workbench )
 			addModelViewer( model, workbench );*/
 		</script>
 		

--- a/brjs-sdk/sdk/templates/default/bladeworkbench/index.html
+++ b/brjs-sdk/sdk/templates/default/bladeworkbench/index.html
@@ -39,14 +39,9 @@
 			var workbench = new Workbench(250, 310);
 			addEventHubLogger( workbench );
 
-			// ViewModel that is being created in the workbench
-			var @bladeTitleViewModel = require( '@bladeRequirePrefix/@bladeTitleViewModel' );
-			var KnockoutComponent = require( 'br/knockout/KnockoutComponent' );
+			var @bladeTitleBlade = require( '@bladeRequirePrefix/@bladeTitleBlade' );
 
-			var model = new @bladeTitleViewModel();
-			var component = new KnockoutComponent( '@bladeNamespace.view-template', model );
-
-			addComponent( component, workbench )
+			addComponent( new @bladeTitleBlade().getComponent(), workbench )
 			addModelViewer( model, workbench );
 		</script>
 	</body>


### PR DESCRIPTION
PR in place of #1195 which was raised against `develop` rather than `master`. Fixes #897. Potentially needs to be revisited once we remove Presenter.