### PR TITLE
ie8 does not tolerate having a keyword as a property name. renamed

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
@@ -32,7 +32,7 @@
 		require('service!br.app-meta-service').setVersion('1.2.3');
 		
 		this.messages = {
-			'default' : {
+			'defaultValue' : {
 				"caplin.test.key": "default value for test key",
 				"other.key": "default value for other key",
 				"untranslated.key": "default value for untranslated key",
@@ -304,7 +304,7 @@
 
 		var sResult = oTranslator.getMessage('untranslated.key', {});
 
-		assertEquals(this.messages.default['untranslated.key'], sResult);
+		assertEquals(this.messages.defaultValue['untranslated.key'], sResult);
 	};
 
 	TranslatorTest.prototype.test_getMessageForAnUntranslatedKeyReturnsTheKeyWithQuestionMarksInDev = function()


### PR DESCRIPTION
having 'default' as a property name was causing ie8 to go mental (expected identifier error). requires renaming the property to  a non-keyword