### PR TITLE
Add getter function for Properties

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/property/Properties.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/property/Properties.js
@@ -60,6 +60,15 @@ Properties.prototype.add = function(vProperties) {
 };
 
 /**
+ * Returns array of properties in the collection.
+ *
+ * @type Array
+ */
+Properties.prototype.getProperties = function() {
+	return this.m_pProperties.slice(0);
+};
+
+/**
  * Returns the size of the collection.
  * 
  * @type int

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/property/PropertiesTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/property/PropertiesTest.js
@@ -30,6 +30,19 @@
         
     };
 
+    PropertiesTest.prototype.test_Getter = function()
+    {
+        var oProperty1 = new Property("p1");
+        var oProperty2 = new Property("p2");
+        var props = [oProperty1, oProperty2];
+
+        var propertiesA = new Properties(props);
+        assertEquals(2, propertiesA.getProperties().length);
+
+        var propertiesB = new Properties();
+        assertEquals([], propertiesB.getProperties());
+    };
+
     PropertiesTest.prototype.test_AddProperty = function()
     {
         var oProperty1 = new Property("p1");


### PR DESCRIPTION
I'd like to attach listeners to the properties of `Properties` via `PropertyHelper` to avoid memory leaks.
PropertyHelper accepts only `Property` objects as arguments.

<!---
@huboard:{"order":1570.0,"milestone_order":1570,"custom_state":""}
-->
