### PR TITLE
Fix i18n translation exceptions

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/DefaultAppVersionGenerator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/DefaultAppVersionGenerator.java
@@ -6,6 +6,8 @@ import java.util.Date;
 
 public class DefaultAppVersionGenerator implements AppVersionGenerator
 {
+	public static final String DEV_VERSION = "dev";
+	
 	private String version = null;
 	private boolean appendTimetamp = true;
 	private String timestamp;

--- a/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/TestRunnerController.java
+++ b/brjs-legacy/src/main/java/org/bladerunnerjs/legacy/command/test/testrunner/TestRunnerController.java
@@ -16,6 +16,7 @@ import org.bladerunnerjs.api.model.exception.modelupdate.ModelUpdateException;
 import org.bladerunnerjs.api.plugin.CommandPlugin;
 import org.bladerunnerjs.legacy.command.test.testrunner.TestRunner.TestType;
 import org.bladerunnerjs.legacy.conf.TestRunnerConfLocator;
+import org.bladerunnerjs.model.DefaultAppVersionGenerator;
 import org.bladerunnerjs.model.ThreadSafeStaticBRJSAccessor;
 import org.bladerunnerjs.api.DirNode;
 
@@ -39,6 +40,8 @@ public class TestRunnerController
 	
 	public int run(BRJS brjs, JSAPResult config, CommandPlugin testCommand) throws CommandArgumentsException, CommandOperationException
 	{
+		brjs.getAppVersionGenerator().setVersion( DefaultAppVersionGenerator.DEV_VERSION );
+		
 		assertValidTestDirectory(brjs, testCommand, config);
 		
 		MemoizedFile configFile = null;

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -386,7 +386,7 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	token = token.toLowerCase();
 
 	if (!this.tokenExists(token)) {
-		if (require('service!br.app-meta-service').getVersion() !== 'dev') {
+		if (!require('service!br.app-meta-service').isDev()) {
 			throw new Errors.InvalidParametersError('Unable to find a replacement for the i18n key "' + token + '"');
 		}
 		var logConsole = (window.jstestdriver) ? jstestdriver.console : window.console;
@@ -396,7 +396,7 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	var message = this.messages[token];
 	if (typeof message === 'undefined') {
 		log.warn(Translator.MESSAGES.UNTRANSLATED_TOKEN_LOG_MSG, token, this.locale);
-		if (require('service!br.app-meta-service').getVersion() !== 'dev') {
+		if (!require('service!br.app-meta-service').isDev()) {
 			message = this.defaultLocaleMessages[token];
 		}
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -386,7 +386,11 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	token = token.toLowerCase();
 
 	if (!this.tokenExists(token)) {
-		throw new Errors.InvalidParametersError('Unable to find a replacement for the i18n key "' + token + '"');
+		if (require('service!br.app-meta-service').getVersion() !== 'dev') {
+			throw new Errors.InvalidParametersError('Unable to find a replacement for the i18n key "' + token + '"');
+		}
+		var logConsole = (window.jstestdriver) ? jstestdriver.console : window.console;
+		logConsole.warn('Unable to find a replacement for the i18n key "' + token + '"');
 	}
 
 	var message = this.messages[token];

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -386,9 +386,6 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	token = token.toLowerCase();
 
 	if (!this.tokenExists(token)) {
-		if (!require('service!br.app-meta-service').isDev()) {
-			throw new Errors.InvalidParametersError('Unable to find a replacement for the i18n key "' + token + '"');
-		}
 		var logConsole = (window.jstestdriver) ? jstestdriver.console : window.console;
 		logConsole.warn('Unable to find a replacement for the i18n key "' + token + '"');
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
@@ -284,10 +284,22 @@
 		_assertGetMessageReturnsCorrectValue(sTest, mTokens, sExpected);
 	};
 
-	TranslatorTest.prototype.test_getMessageForAnUnknownKeyThrowsAnError = function()
+	TranslatorTest.prototype.test_getMessageForAnUnknownKeyReturnsAnEmptyTranslationInDev = function()
 	{
 		var sKey = "unknown.key";
 		var sExpected = "??? " + sKey + " ???";
+		require('service!br.app-meta-service').setVersion('dev');
+
+		var Translator = require('br/i18n/Translator');
+		var oTranslator = new Translator({});
+
+		assertEquals(oTranslator.getMessage(sKey, {}), sExpected);
+	};
+	
+	TranslatorTest.prototype.test_getMessageForAnUnknownKeyThrowsAnErrorInProd = function()
+	{
+		var sKey = "unknown.key";
+		require('service!br.app-meta-service').setVersion('1.2.3');
 
 		var Translator = require('br/i18n/Translator');
 		var oTranslator = new Translator({});

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
@@ -299,14 +299,13 @@
 	TranslatorTest.prototype.test_getMessageForAnUnknownKeyThrowsAnErrorInProd = function()
 	{
 		var sKey = "unknown.key";
+		var sExpected = "??? " + sKey + " ???";
 		require('service!br.app-meta-service').setVersion('1.2.3');
 
 		var Translator = require('br/i18n/Translator');
 		var oTranslator = new Translator({});
-
-		assertException(function() {
-			oTranslator.getMessage(sKey, {});
-		}, "InvalidParametersError");
+		
+		assertEquals(oTranslator.getMessage(sKey, {}), sExpected);
 	};
 
 	TranslatorTest.prototype.test_getMessageForAnUntranslatedKeyReturnsDefaultLocaleMessageInProd = function()

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/resources/en.properties
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/resources/en.properties
@@ -3,6 +3,7 @@ br.presenter.datefield.invalidValueType=DateField.value must be a string.
 
 br.presenter.validator.invalidSelection=[value] is not a valid selection.
 br.presenter.validator.invalidSelectionsAllowed=Invalid selections allowed.
+br.presenter.validator.invalidSelection=Invalid selection.
 
 br.presenter.validator.invalidISODateFormat=Invalid date [value]. Date must be in YYYY-MM-DD or YYYYMMDD format.
 br.presenter.validator.valueNullUndefinedOrEmptyString=Value was null/undefined or empty string.

--- a/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/AppMetaService.js
+++ b/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/AppMetaService.js
@@ -26,6 +26,14 @@ AppMetaService.prototype.getVersion = function() {
 };
 
 /**
+* Returns true if the app is running in 'dev' mode, false otherwise.
+* @returns true if the app is running in 'dev' mode, false otherwise.
+*/
+AppMetaService.prototype.isDev = function() {
+	throw new Errors.UnimplementedInterfaceError("AppMetaService.isDev() has not been implemented.");
+};
+
+/**
 * Returns the path to content plugins/bundles.
 * @param {String} [bundlePath] The path to a bundle to be appended to the returned path
 * @returns The path to content plugins/bundles.

--- a/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/appmeta/BRAppMetaService.js
+++ b/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/appmeta/BRAppMetaService.js
@@ -25,6 +25,10 @@ BRAppMetaService.prototype.getVersion = function() {
 	return metaData.APP_VERSION;
 };
 
+BRAppMetaService.prototype.isDev = function() {
+	return this.getVersion() === "dev";
+};
+
 BRAppMetaService.prototype.getVersionedBundlePath = function(bundlePath) {
 	return getBundlePath(metaData.VERSIONED_BUNDLE_PATH, bundlePath);
 };

--- a/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/appmeta/JSTDAppMetaService.js
+++ b/brjs-sdk/sdk/libs/javascript/br-services/src/br/services/appmeta/JSTDAppMetaService.js
@@ -26,6 +26,10 @@ JSTDAppMetaService.prototype.getVersion = function() {
 	return this._testMetaData.APP_VERSION || BRAppMetaService.prototype.getVersion.call(this);
 };
 
+JSTDAppMetaService.prototype.isDev = function() {
+	return this.getVersion() === "dev";
+};
+
 /**
  * Sets the app version to be used in the test.
  * @param {String} version The app version.

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPlugin.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPlugin.java
@@ -70,11 +70,12 @@ public class HTMLBundlerTagHandlerPlugin extends AbstractTagHandlerPlugin {
 			String keyReplacement = propertiesMap.get(i18nKey);
 			if (keyReplacement == null) {
 				keyReplacement = defaultLocalpropertiesMap.get(i18nKey);
-				if (keyReplacement == null) {
-					throw new ContentProcessingException("Unable to find a replacement for the i18n key '"+i18nKey+"'");
-				}
 				if (requestMode.equals(RequestMode.Dev)) {
 					keyReplacement = "??? "+i18nKey+" ???";
+				} else {
+					if (keyReplacement == null) {
+						throw new ContentProcessingException("Unable to find a replacement for the i18n key '"+i18nKey+"'");
+					}
 				}
 				logger.warn(Messages.UNTRANSLATED_TOKEN_LOG_MSG, i18nKey, locale);
 			}

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPlugin.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPlugin.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 import org.bladerunnerjs.api.BRJS;
 import org.bladerunnerjs.api.BundleSet;
-import org.bladerunnerjs.api.App.Messages;
 import org.bladerunnerjs.api.logging.Logger;
 import org.bladerunnerjs.api.model.exception.ConfigException;
 import org.bladerunnerjs.api.model.exception.request.ContentProcessingException;

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/commands/standard/ServeCommand.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/commands/standard/ServeCommand.java
@@ -18,6 +18,7 @@ import com.martiansoftware.jsap.JSAPException;
 import com.martiansoftware.jsap.JSAPResult;
 
 import org.bladerunnerjs.logger.LogLevel;
+import org.bladerunnerjs.model.DefaultAppVersionGenerator;
 import org.bladerunnerjs.utility.AppRequestHandler;
 import org.bladerunnerjs.utility.J2EEAppLoggingMissingTokenHandler;
 
@@ -66,7 +67,7 @@ public class ServeCommand extends JSAPArgsParsingCommandPlugin
 	protected void configureArgsParser(JSAP argsParser) throws JSAPException
 	{
 		argsParser.registerParameter(new FlaggedOption("port").setShortFlag('p').setLongFlag("port").setRequired(false).setHelp("the port number to run the BRJS application (overrides config)"));
-		argsParser.registerParameter(new FlaggedOption("version").setShortFlag('v').setLongFlag("version").setRequired(false).setDefault("dev").setHelp("the version number for the app"));
+		argsParser.registerParameter(new FlaggedOption("version").setShortFlag('v').setLongFlag("version").setRequired(false).setDefault(DefaultAppVersionGenerator.DEV_VERSION).setHelp("the version number for the app"));
 		argsParser.registerParameter(new FlaggedOption("environment").setShortFlag('e').setLongFlag("environment").setRequired(false)
 				.setDefault("dev").setHelp("the environment to use when locating app properties"));
 	}

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPluginTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPluginTest.java
@@ -70,11 +70,13 @@ public class HTMLBundlerTagHandlerPluginTest extends SpecTest
 	}
 	
 	@Test
-	public void exceptionIsThrownIfAnI18nReplacementCantBeFound() throws Exception {
+	public void questionMarkReplacementIsUsedIfAnI18nReplacementCantBeFoundAndTheresNoFallback() throws Exception {
 		given(aspect).containsResourceFileWithContents("html/view.html", "<template id='appns.view'>@{appns.i18n.token}</template>")
-			.and(aspect).indexPageHasContent("<@html.bundle@/>");
+			.and(aspect).indexPageHasContent("<@html.bundle@/>")
+			.and(logging).enabled();
 		when(aspect).indexPageLoadedInDev(indexPageResponse, "en_GB");
-		then(exceptions).verifyException(ContentProcessingException.class, "appns.i18n.token");
+		then(indexPageResponse).containsText("??? appns.i18n.token ???")
+			.and(logging).warnMessageReceived(UNTRANSLATED_TOKEN_LOG_MSG, "appns.i18n.token", "en_GB");
 	}
 	
 	@Test

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPluginTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/plugin/bundlers/html/HTMLBundlerTagHandlerPluginTest.java
@@ -2,7 +2,6 @@ package org.bladerunnerjs.plugin.bundlers.html;
 
 import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.Aspect;
-import org.bladerunnerjs.api.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.junit.Before;
 import org.junit.Test;

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
@@ -11,6 +11,7 @@ import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.model.SdkJsLib;
 import org.bladerunnerjs.api.BladeWorkbench;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -383,4 +384,151 @@ public class I18nContentPluginTest extends SpecTest
 		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
 		then(response).containsText("\"appns.property\": \"property value\"");
 	}
+	
+	
+	/* ** Dependencies from HTML files ** */
+	
+	@Test
+	public void i18nPropertiesInBladesetResourcesReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.key@}</div>")
+    		.and(bladeset).containsFileWithContents("resources/en_GB.properties", "appns.bs.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladesetSrcReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.key@}</div>")
+    		.and(bladeset).containsFileWithContents("src/en_GB.properties", "appns.bs.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladeResourcesReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.b1.key@}</div>")
+			.and(blade).containsFileWithContents("resources/en_GB.properties", "appns.bs.b1.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladeSrcReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.b1.key@}</div>")
+			.and(blade).containsFileWithContents("src/en_GB.properties", "appns.bs.b1.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibResourcesReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("resources/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibResourcesReferencedFromAnotherLibTestHtmlTemplateAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("resources/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcReferencedFromAotherLibTestHtmlTemplateAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	
+	/* ** Dependencies from XML files ** */
+	
+	@Test
+	public void i18nPropertiesInBladesetResourcesReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.key@}</div>")
+    		.and(bladeset).containsFileWithContents("resources/en_GB.properties", "appns.bs.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladesetSrcReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.key@}</div>")
+    		.and(bladeset).containsFileWithContents("src/en_GB.properties", "appns.bs.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladeResourcesReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.b1.key@}</div>")
+			.and(blade).containsFileWithContents("resources/en_GB.properties", "appns.bs.b1.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.key\": \"translation\"");
+	}
+	
+	@Test
+	public void i18nPropertiesInBladeSrcReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.b1.key@}</div>")
+			.and(blade).containsFileWithContents("src/en_GB.properties", "appns.bs.b1.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibResourcesReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("resources/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibResourcesReferencedFromAnotherLibTestXmlFileAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("config.xml", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("resources/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcReferencedFromAotherLibTestXmlFileAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("config.xml", "<div>@{lib.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
 }

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/i18n/I18nContentPluginTest.java
@@ -404,6 +404,14 @@ public class I18nContentPluginTest extends SpecTest
     	then(response).containsText("\"appns.bs.key\": \"translation\"");
 	}
 	
+	@Test @Ignore
+	public void i18nPropertiesInBladesetSrcPackageDirReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.pkg.key@}</div>")
+    		.and(bladeset).containsFileWithContents("src/pkg/en_GB.properties", "appns.bs.pkg.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.pkg.key\": \"translation\"");
+	}
+	
 	@Test
 	public void i18nPropertiesInBladeResourcesReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
 		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.b1.key@}</div>")
@@ -421,6 +429,14 @@ public class I18nContentPluginTest extends SpecTest
 	}
 	
 	@Test @Ignore
+	public void i18nPropertiesInBladeSrcPackageDirReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{appns.bs.b1.pkg.key@}</div>")
+			.and(blade).containsFileWithContents("src/pkg/en_GB.properties", "appns.bs.b1.pkg.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.pkg.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
 	public void i18nPropertiesInLibResourcesReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
 		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
 			.and(sdkLib).containsFileWithContents("resources/en_GB.properties", "lib.key=translation")
@@ -433,6 +449,15 @@ public class I18nContentPluginTest extends SpecTest
 	public void i18nPropertiesInLibSrcReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
 		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{lib.key@}</div>")
 			.and(sdkLib).containsFileWithContents("src/en_GB.properties", "lib.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcPackageDirReferencedFromAnAspectHtmlTemplateAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("view.html", "<div>@{lib.pkg.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/pkg/en_GB.properties", "lib.pkg.key=translation")
 			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
 		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
 		then(response).containsText("\"lib.key\": \"translation\"");
@@ -458,6 +483,16 @@ public class I18nContentPluginTest extends SpecTest
 		then(response).containsText("\"lib.key\": \"translation\"");
 	}
 	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcPackageDirReferencedFromAotherLibTestHtmlTemplateAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("view.html", "<div>@{lib.pkg.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/pkg/en_GB.properties", "lib.pkg.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.pkg.key\": \"translation\"");
+	}
+	
 	
 	/* ** Dependencies from XML files ** */
 	
@@ -477,6 +512,14 @@ public class I18nContentPluginTest extends SpecTest
     	then(response).containsText("\"appns.bs.key\": \"translation\"");
 	}
 	
+	@Test @Ignore
+	public void i18nPropertiesInBladesetSrcPackageDirReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.pkg.key@}</div>")
+    		.and(bladeset).containsFileWithContents("src/pkg/en_GB.properties", "appns.bs.pkg.key=translation");
+    	when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+    	then(response).containsText("\"appns.bs.pkg.key\": \"translation\"");
+	}
+	
 	@Test
 	public void i18nPropertiesInBladeResourcesReferencedFromAnAspectXmlFileAreBundled() throws Exception {
 		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.b1.key@}</div>")
@@ -491,6 +534,14 @@ public class I18nContentPluginTest extends SpecTest
 			.and(blade).containsFileWithContents("src/en_GB.properties", "appns.bs.b1.key=translation");
 		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
 		then(response).containsText("\"appns.bs.b1.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInBladeSrcPackageDirReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{appns.bs.b1.pkg.key@}</div>")
+			.and(blade).containsFileWithContents("src/pkg/en_GB.properties", "appns.bs.b1.pkg.key=translation");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"appns.bs.b1.pkg.key\": \"translation\"");
 	}
 	
 	@Test @Ignore
@@ -512,6 +563,15 @@ public class I18nContentPluginTest extends SpecTest
 	}
 	
 	@Test @Ignore
+	public void i18nPropertiesInLibSrcPackageDirReferencedFromAnAspectXmlFileAreBundled() throws Exception {
+		given(defaultAspect).containsResourceFileWithContents("config.xml", "<div>@{lib.pkg.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/pkg/en_GB.properties", "lib.pkg.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(defaultAspect).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.pkg.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
 	public void i18nPropertiesInLibResourcesReferencedFromAnotherLibTestXmlFileAreBundled() throws Exception {
 		SdkJsLib sdkLib2 = brjs.sdkLib("test");
 		given(sdkLib2).containsResourceFileWithContents("config.xml", "<div>@{lib.key@}</div>")
@@ -529,6 +589,16 @@ public class I18nContentPluginTest extends SpecTest
 			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
 		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
 		then(response).containsText("\"lib.key\": \"translation\"");
+	}
+	
+	@Test @Ignore
+	public void i18nPropertiesInLibSrcPackageDirReferencedFromAotherLibTestXmlFileAreBundled() throws Exception {
+		SdkJsLib sdkLib2 = brjs.sdkLib("test");
+		given(sdkLib2).containsResourceFileWithContents("config.xml", "<div>@{lib.pkg.key@}</div>")
+			.and(sdkLib).containsFileWithContents("src/pkg/en_GB.properties", "lib.pkg.key=translation")
+			.and(sdkLib).containsFileWithContents("br-lib.conf", "requirePrefix: appns");
+		when(sdkLib2.testType("ut").defaultTestTech()).requestReceivedInDev("i18n/en_GB.js", response);
+		then(response).containsText("\"lib.pkg.key\": \"translation\"");
 	}
 	
 }


### PR DESCRIPTION
Fix exceptions thrown when i18n translations cant be found. This broke backwards compatibility after #1564 was merged so we now don't throw the exceptions.