### PR TITLE
Validating and Focus Flags. (to be merged 01/04/16)

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/Field.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/Field.js
@@ -70,6 +70,20 @@ function Field(vValue) {
 	this.visible = new WritableProperty(true);
 
 	/**
+	 * A boolean property representing whether the input field is currently validating
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.isValidationInProgress = new WritableProperty(false);
+
+	/**
+	 * A boolean property representing whether the input field is currently focused.
+	 * Not all fields will care about tracking whether they have focus or not. For these fields leaving hasFocus
+	 * as undefined seems the most appropriate choice.
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.hasFocus = new WritableProperty(undefined);
+
+	/**
 	 * The logical control-name the field is being bound to &mdash; this
 	 * value will appear within the <code>name</code> attribute if being bound
 	 * to a native HTML control.

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/FieldValuePropertyListener.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/FieldValuePropertyListener.js
@@ -31,7 +31,16 @@ Core.inherit(FieldValuePropertyListener, PropertyListener);
  * @private
  * @see br.presenter.property.PropertyListener#onValidationSuccess
  */
+FieldValuePropertyListener.prototype.onPropertyChanged = function() {
+	this.m_oField.isValidationInProgress.setValue(true);
+};
+
+/**
+ * @private
+ * @see br.presenter.property.PropertyListener#onValidationSuccess
+ */
 FieldValuePropertyListener.prototype.onValidationSuccess = function(vPropertyValue, sErrorMessage) {
+	this.m_oField.isValidationInProgress.setValue(false);
 	this.m_oField.hasError.setValue(false);
 	this.m_oField.failureMessage.setValue('');
 };
@@ -41,6 +50,7 @@ FieldValuePropertyListener.prototype.onValidationSuccess = function(vPropertyVal
  * @see br.presenter.property.PropertyListener#onValidationError
  */
 FieldValuePropertyListener.prototype.onValidationError = function(vPropertyValue, sErrorMessage) {
+	this.m_oField.isValidationInProgress.setValue(false);
 	this.m_oField.hasError.setValue(true);
 	this.m_oField.failureMessage.setValue(sErrorMessage);
 };

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/MultiSelectionField.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/MultiSelectionField.js
@@ -99,6 +99,20 @@ function MultiSelectionField(vOptions, vValues) {
 	this.visible = new WritableProperty(true);
 
 	/**
+	 * A boolean property representing whether the input field is currently validating
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.isValidationInProgress = new WritableProperty(false);
+
+	/**
+	 * A boolean property representing whether the input field is currently focused.
+	 * Not all fields will care about tracking whether they have focus or not. For these fields leaving hasFocus
+	 * as undefined seems the most appropriate choice.
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.hasFocus = new WritableProperty(undefined);
+
+	/**
 	 * The logical control-name the multi-selection field is being bound to &mdash; this
 	 * value will appear within the <code>name</code> attribute if being bound to a native HTML control.
 	 * @type br.presenter.property.WritableProperty

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/node/SelectionField.js
@@ -85,6 +85,20 @@ function SelectionField(vOptions, vValue) {
 	this.visible = new WritableProperty(true);
 
 	/**
+	 * A boolean property representing whether the input field is currently validating
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.isValidationInProgress = new WritableProperty(false);
+
+	/**
+	 * A boolean property representing whether the input field is currently focused.
+	 * Not all fields will care about tracking whether they have focus or not. For these fields leaving hasFocus
+	 * as undefined seems the most appropriate choice.
+	 * @type br.presenter.property.WritableProperty
+	 */
+	this.hasFocus = new WritableProperty(undefined);
+
+	/**
 	 * The logical control-name the selection field is being bound to &mdash; this
 	 * value will appear within the <code>name</code> attribute if being bound to a native HTML control.
 	 * @type br.presenter.property.WritableProperty


### PR DESCRIPTION
This patch adds a flag to track whether validation is currently in progress. This is important for fields where the validation is asynchronous. We generally do not want to be displaying an error while this is occurring, but we also want to ensure we have a mechanism to disable other functionality until the field has been validated.

Also included in this patch is a hasFocus attribute, which can be used by controls to indicate that the field is focused. This is useful for date fields, as the field is not validated until it has lost focus. When this is the case we want to disable other functionality until we know that the date is valid.

<!---
@huboard:{"order":1.20703125,"milestone_order":1589,"custom_state":""}
-->
