### PR TITLE
returning the value to be formatted when not a string or empty

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/I18N.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/I18N.js
@@ -19,6 +19,10 @@ I18N.create = function(translator) {
 	* @see {@link br/i18n/Translator:#getMessage}
 	*/
 	var i18n = function(thingToFormat, mTemplateArgs) {
+		if(typeof thingToFormat !== "string" || thingToFormat === ""){
+			return thingToFormat;
+		}
+
 		return translator.getMessage(thingToFormat, mTemplateArgs);
 	};
 


### PR DESCRIPTION
helps us stay backwardly compatible and avoid showing too many console warnings when tests lazily use empty string as i18n tokens

<!---
@huboard:{"order":64.03125,"milestone_order":1605,"custom_state":""}
-->
