### PR TITLE
ensuring ie8 doesnt blow up on i18n warnings when console isnt open

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -386,6 +386,10 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	token = token.toLowerCase();
 
 	if (!this.tokenExists(token)) {
+		if (typeof window.console === "undefined") {
+			window.console = {};
+			window.console.warn = function(){};
+		}
 		var logConsole = (window.jstestdriver) ? jstestdriver.console : window.console;
 		logConsole.warn('Unable to find a replacement for the i18n key "' + token + '"');
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -386,12 +386,10 @@ Translator.prototype._getTranslationForKeyOrUndefined = function(token) {
 	token = token.toLowerCase();
 
 	if (!this.tokenExists(token)) {
-		if (typeof window.console === "undefined") {
-			window.console = {};
-			window.console.warn = function(){};
-		}
 		var logConsole = (window.jstestdriver) ? jstestdriver.console : window.console;
-		logConsole.warn('Unable to find a replacement for the i18n key "' + token + '"');
+		if (logConsole && logConsole.warn) {
+		    logConsole.warn('Unable to find a replacement for the i18n key "' + token + '"');
+		}
 	}
 
 	var message = this.messages[token];


### PR DESCRIPTION

apps with missing i18n tokens wouldnt open in ie8 due to console warning. (window.console undefined... that old chestnut!)