### PR TITLE
Bugfix clearnode now removes the node

### DIFF
--- a/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
@@ -89,7 +89,7 @@ public abstract class AbstractRootNode extends AbstractNode implements RootNode
 	public void clearRegisteredNode(Node node) {
 		String normalizedPath = node.dir().getAbsolutePath();
 		List<Node> nodesForPath = nodeCache.get(normalizedPath);
-		nodesForPath.remove(node.getTypeName());
+		nodesForPath.remove(node);
 	}
 	
 	@Override

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/engine/AbstractRootNode.java
@@ -86,13 +86,6 @@ public abstract class AbstractRootNode extends AbstractNode implements RootNode
 	}
 	
 	@Override
-	public void clearRegisteredNode(Node node) {
-		String normalizedPath = node.dir().getAbsolutePath();
-		List<Node> nodesForPath = nodeCache.get(normalizedPath);
-		nodesForPath.remove(node);
-	}
-	
-	@Override
 	public List<Node> getRegisteredNodes(MemoizedFile childPath)
 	{
 		String normalizedPath = childPath.getAbsolutePath();

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/engine/RootNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/engine/RootNode.java
@@ -26,7 +26,6 @@ public interface RootNode extends Node {
 	
 	boolean isNodeRegistered(Node node);
 	void registerNode(Node node) throws NodeAlreadyRegisteredException;
-	void clearRegisteredNode(Node node);
 	Node getRegisteredNode(MemoizedFile childPath) throws MultipleNodesForPathException;
 	Node getRegisteredNode(MemoizedFile childPath, Class<? extends Node> nodeClass) throws MultipleNodesForPathException;
 	List<Node> getRegisteredNodes(MemoizedFile childPath);

--- a/brjs-core/src/test/java/org/bladerunnerjs/model/engine/MockRootNode.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/model/engine/MockRootNode.java
@@ -169,11 +169,6 @@ public class MockRootNode implements RootNode
 	}	
 	
 	@Override
-	public void clearRegisteredNode(Node node)
-	{
-	}
-	
-	@Override
 	public Node getRegisteredNode(MemoizedFile childPath)
 	{
 		return null;


### PR DESCRIPTION
previously the remove method was being passed a string which would not clear the node

<!---
@huboard:{"order":1480.0,"milestone_order":1614,"custom_state":""}
-->
