### PR TITLE
Coderefactor aliasdef method incorrect param

### DIFF
--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/aliasing/AliasDefinitionsData.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/aliasing/AliasDefinitionsData.java
@@ -21,7 +21,7 @@ public class AliasDefinitionsData {
 	}
 	
 	public boolean equals(AliasDefinitionsData aliasDefinitionsData) {
-		return aliasDefinitions.equals(aliasDefinitionsData) && scenarioAliases.equals(aliasDefinitionsData.scenarioAliases) && groupAliases.equals(aliasDefinitionsData.groupAliases);
+		return aliasDefinitions.equals(aliasDefinitionsData.aliasDefinitions) && scenarioAliases.equals(aliasDefinitionsData.scenarioAliases) && groupAliases.equals(aliasDefinitionsData.groupAliases);
 	}
 	
 	public Map<String, AliasOverride> getScenarioAliases(String aliasName) {


### PR DESCRIPTION
incorrect arg was being passed into object comparison which could lead to incorrect results for aliasDef equals method