### PR TITLE
Use Map of require path to SourceModule to fix NPE (#1517)

### DIFF
--- a/brjs-core-tests/src/test-integration/java/org/bladerunnerjs/memoization/WatchingFileModificationObserverThreadTest.java
+++ b/brjs-core-tests/src/test-integration/java/org/bladerunnerjs/memoization/WatchingFileModificationObserverThreadTest.java
@@ -22,7 +22,6 @@ import org.bladerunnerjs.memoization.WatchingFileModificationObserver;
 import org.bladerunnerjs.utility.FileUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/StandardBundleSet.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/StandardBundleSet.java
@@ -11,17 +11,18 @@ import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.api.BundleSet;
 import org.bladerunnerjs.api.LinkedAsset;
 import org.bladerunnerjs.api.SourceModule;
+import org.bladerunnerjs.utility.AssetMap;
 
 public class StandardBundleSet implements BundleSet {
-	private final List<LinkedAsset> seedAssets;
-	private final List<Asset> assets;
-	private final List<SourceModule> sourceModules;
+	private final AssetMap<LinkedAsset> seedAssets;
+	private final AssetMap<Asset> assets;
+	private final AssetMap<SourceModule> sourceModules;
 	private BundlableNode bundlableNode;
 	
 	private Map<List<Class<? extends Asset>>, List<Asset>> assetsByType = new HashMap<>();
 	private Map<List<Class<? extends SourceModule>>, List<SourceModule>> sourceModulesByType = new HashMap<>();
 	
-	public StandardBundleSet(BundlableNode bundlableNode, List<LinkedAsset> seedAssets, List<Asset> assets, List<SourceModule> sourceModules) {
+	public StandardBundleSet(BundlableNode bundlableNode, AssetMap<LinkedAsset> seedAssets, AssetMap<Asset> assets, AssetMap<SourceModule> sourceModules) {
 		this.seedAssets = seedAssets;
 		this.bundlableNode = bundlableNode;
 		this.assets = assets;
@@ -36,7 +37,7 @@ public class StandardBundleSet implements BundleSet {
 	@Override
 	public List<LinkedAsset> seedAssets()
 	{
-		return seedAssets;
+		return seedAssets.values();
 	}
 	
 	@Override
@@ -77,7 +78,7 @@ public class StandardBundleSet implements BundleSet {
 	
 	
 	
-	private static <AT extends Asset> List<AT> getTheAssets(List<AT> assets, Map<List<Class<? extends AT>>, List<AT>> assetsByType, 
+	private static <AT extends Asset> List<AT> getTheAssets(AssetMap<AT> assets, Map<List<Class<? extends AT>>, List<AT>> assetsByType, 
 			List<String> prefixes, List<Class<? extends AT>> assetTypes) {
 		
 		List<AT> assetsOfCorrectType = getAssetsForType(assets, assetsByType, assetTypes);
@@ -96,15 +97,15 @@ public class StandardBundleSet implements BundleSet {
 		return assetsWithRequirePath;
 	}
 	
-	private static <AT extends Asset> List<AT> getAssetsForType(List<AT> assets, Map<List<Class<? extends AT>>, List<AT>> assetsByType, List<Class<? extends AT>> assetTypes) {
+	private static <AT extends Asset> List<AT> getAssetsForType(AssetMap<AT> assets, Map<List<Class<? extends AT>>, List<AT>> assetsByType, List<Class<? extends AT>> assetTypes) {
 		if (assetTypes == null || assetTypes.isEmpty()) {
-			return assets;
+			return assets.values();
 		}
 		
 		List<AT> assetsForAssetsTypes = getAssetsForType(assetsByType, assetTypes);
 		if (assetsForAssetsTypes == null) {
 			assetsForAssetsTypes = new ArrayList<>();
-			for (AT asset : assets) {
+			for (AT asset : assets.values()) {
 				if (assetHasValidType(asset, assetTypes)) {
 					assetsForAssetsTypes.add(asset);
 				}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/AssetMap.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/AssetMap.java
@@ -1,7 +1,8 @@
 package org.bladerunnerjs.utility;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -13,6 +14,13 @@ public class AssetMap<AT extends Asset>
 {
 
 	Map<String,AT> internalMap = new LinkedHashMap<>();
+	
+	public AssetMap() {
+	}
+	
+	public AssetMap(AssetMap<AT> assets) {
+		putAll(assets);
+	}
 	
 	public int size()
 	{
@@ -46,6 +54,7 @@ public class AssetMap<AT extends Asset>
 	
 	public boolean put(String key, AT value)
 	{
+//		return (internalMap.putIfAbsent(key, value) == null);
 		if (containsKey(key)) {
 			return false;
 		}
@@ -58,14 +67,32 @@ public class AssetMap<AT extends Asset>
 		return put(asset.getPrimaryRequirePath(), asset);
 	}
 	
+	public void putFirst(AssetMap<AT> assetMap)
+	{
+		Map<String,AT> newInternalMap = new LinkedHashMap<>();
+		newInternalMap.putAll(assetMap.internalMap);
+		newInternalMap.putAll(internalMap);
+		internalMap = newInternalMap;
+	}
+	
 	public AT remove(String key)
 	{
 		return internalMap.remove(key);
 	}
 	
+	public AT remove(AT asset)
+	{
+		return remove(asset.getPrimaryRequirePath());
+	}
+	
 	public void putAll(Map<? extends String, ? extends AT> m)
 	{
 		internalMap.putAll(m);
+	}
+	
+	public void putAll(AssetMap<AT> assetMap)
+	{
+		internalMap.putAll(assetMap.internalMap);
 	}
 	
 	public void clear()
@@ -78,9 +105,9 @@ public class AssetMap<AT extends Asset>
 		return internalMap.keySet();
 	}
 	
-	public Collection<AT> values()
+	public List<AT> values()
 	{
-		return internalMap.values();
+		return new ArrayList<>(internalMap.values());
 	}
 
 	public Set<Entry<String, AT>> entrySet()

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/AssetMap.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/AssetMap.java
@@ -1,0 +1,91 @@
+package org.bladerunnerjs.utility;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.bladerunnerjs.api.Asset;
+
+// this class implements all methods of Map<String,AT> but doesn't implement Map so we can enforce the correct argument type in methods like 'containsKey'
+public class AssetMap<AT extends Asset>
+{
+
+	Map<String,AT> internalMap = new LinkedHashMap<>();
+	
+	public int size()
+	{
+		return internalMap.size();
+	}
+	
+	public boolean isEmpty()
+	{
+		return internalMap.isEmpty();
+	}
+	
+	public boolean containsKey(String requirePath)
+	{
+		return internalMap.containsKey(requirePath);
+	}
+	
+	public boolean containsKey(AT asset)
+	{
+		return containsKey(asset.getPrimaryRequirePath());
+	}
+	
+	public boolean containsValue(AT value)
+	{
+		return internalMap.containsValue(value);
+	}
+
+	public AT get(String key)
+	{
+		return internalMap.get(key);
+	}
+	
+	public boolean put(String key, AT value)
+	{
+		if (containsKey(key)) {
+			return false;
+		}
+		internalMap.put(key, value);
+		return true;
+	}
+	
+	public boolean put(AT asset)
+	{
+		return put(asset.getPrimaryRequirePath(), asset);
+	}
+	
+	public AT remove(String key)
+	{
+		return internalMap.remove(key);
+	}
+	
+	public void putAll(Map<? extends String, ? extends AT> m)
+	{
+		internalMap.putAll(m);
+	}
+	
+	public void clear()
+	{
+		internalMap.clear();
+	}
+	
+	public Set<String> keySet()
+	{
+		return internalMap.keySet();
+	}
+	
+	public Collection<AT> values()
+	{
+		return internalMap.values();
+	}
+
+	public Set<Entry<String, AT>> entrySet()
+	{
+		return internalMap.entrySet();
+	}
+
+}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
@@ -65,7 +65,7 @@ public class BundleSetBuilder {
 			addBootstrapAndDependencies(bootstrappingSourceModules);
 		}
 		
-		List<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, new ArrayList<>(bootstrappingSourceModules.values()), new LinkedHashSet<>(sourceModules.values()));
+		List<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, bootstrappingSourceModules, sourceModules);
 		List<Asset> assetList = orderAssetsByAssetContainer( new LinkedHashSet<>(assets.values()) );
 		
 		return new StandardBundleSet(bundlableNode, new ArrayList<>(seedAssets.values()), assetList, orderedSourceModules);

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
@@ -63,10 +63,10 @@ public class BundleSetBuilder {
 			addBootstrapAndDependencies(bootstrappingSourceModules);
 		}
 		
-		List<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, bootstrappingSourceModules, sourceModules);
-		List<Asset> assetList = orderAssetsByAssetContainer( new LinkedHashSet<>(assets.values()) );
+		AssetMap<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, bootstrappingSourceModules, sourceModules);
+		AssetMap<Asset> assetList = orderAssetsByAssetContainer(assets);
 		
-		return new StandardBundleSet(bundlableNode, new ArrayList<>(seedAssets.values()), assetList, orderedSourceModules);
+		return new StandardBundleSet(bundlableNode, seedAssets, assetList, orderedSourceModules);
 	}
 
 	public void addSeedFiles(List<LinkedAsset> seedFiles) throws ModelOperationException {
@@ -233,18 +233,18 @@ public class BundleSetBuilder {
 		}
 	}
 	
-	private <AT extends Asset> List<AT> orderAssetsByAssetContainer(Set<? extends AT> assets) {
-		List<AT> orderedAssets = new ArrayList<>();
-		List<AT> unorderedAssets = new ArrayList<>(assets);
+	private <AT extends Asset> AssetMap<AT> orderAssetsByAssetContainer(AssetMap<AT> assets) {
+		AssetMap<AT> orderedAssets = new AssetMap<>();
+		AssetMap<AT> unorderedAssets = new AssetMap<>(assets);
 		for (AssetContainer assetContainer : bundlableNode.scopeAssetContainers()) {
-			for (AT asset : assets) {
+			for (AT asset : assets.values()) {
 				if (asset.assetContainer() == assetContainer) {
-					orderedAssets.add(asset);
+					orderedAssets.put(asset);
 					unorderedAssets.remove(asset);
 				}
 			}
 		}
-		orderedAssets.addAll(0, unorderedAssets);
+		orderedAssets.putFirst(unorderedAssets);
 		return orderedAssets;
 	}	
 	

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/BundleSetBuilder.java
@@ -2,8 +2,10 @@ package org.bladerunnerjs.utility;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.bladerunnerjs.api.Asset;
@@ -34,10 +36,11 @@ public class BundleSetBuilder {
 			" This allows the Blade class to directly depend on another Blade class when the App loaded. This dependency should be broken using Services and the file '%s' should be removed to re-enable the scope enforcement.";
 	public static final String INVALID_REQUIRE_MSG = "The class '%s' depends on the class '%s' which is outside of it's scope - this dependency should be broken using Services.";
 	
-	private final List<LinkedAsset> seedAssets = new ArrayList<>();
-	private final Set<Asset> assets = new LinkedHashSet<>();
-	private final Set<SourceModule> sourceModules = new LinkedHashSet<>();
-	private final Set<Asset> processedAssets = new LinkedHashSet<>();
+	// use Maps rather than Lists and Sets so we're in control of what's used as the key rather than relying on #equals being implemented properly
+	private final Map<String,LinkedAsset> seedAssets = new LinkedHashMap<>();
+	private final Map<String,Asset> assets = new LinkedHashMap<>();
+	private final Map<String,SourceModule> sourceModules = new LinkedHashMap<>();
+	private final Set<String> processedAssets = new LinkedHashSet<>();
 	private final BundlableNode bundlableNode;
 	private final Logger logger;
 	private Set<Asset> strictCheckingAssetsLogged = new HashSet<>();
@@ -56,20 +59,22 @@ public class BundleSetBuilder {
 			}
 		}
 		
-		List<SourceModule> bootstrappingSourceModules = new ArrayList<SourceModule>();
+		Map<String,SourceModule> bootstrappingSourceModules = new LinkedHashMap<>();
 		if (!sourceModules.isEmpty())
 		{
 			addBootstrapAndDependencies(bootstrappingSourceModules);
 		}
 		
-		List<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, bootstrappingSourceModules, sourceModules);
-		List<Asset> assetList = orderAssetsByAssetContainer(assets);
+		List<SourceModule> orderedSourceModules = SourceModuleDependencyOrderCalculator.getOrderedSourceModules(bundlableNode, new ArrayList<>(bootstrappingSourceModules.values()), new LinkedHashSet<>(sourceModules.values()));
+		List<Asset> assetList = orderAssetsByAssetContainer( new LinkedHashSet<>(assets.values()) );
 		
-		return new StandardBundleSet(bundlableNode, seedAssets, assetList, orderedSourceModules);
+		return new StandardBundleSet(bundlableNode, new ArrayList<>(seedAssets.values()), assetList, orderedSourceModules);
 	}
 
 	public void addSeedFiles(List<LinkedAsset> seedFiles) throws ModelOperationException {
-		seedAssets.addAll(seedFiles);
+		for (LinkedAsset asset : seedFiles) {
+			seedAssets.put(asset.getPrimaryRequirePath(), asset);
+		}
 		for(LinkedAsset seedFile : seedFiles) {
 			addLinkedAsset(seedFile);
 		}
@@ -77,15 +82,15 @@ public class BundleSetBuilder {
 	
 	
 	private void addSourceModule(SourceModule sourceModule) throws ModelOperationException {
-		if (sourceModules.add(sourceModule)) {
+		if (addToAssetMap(sourceModules, sourceModule)) {
 			addLinkedAsset(sourceModule);
 		}
 	}
 
 	private void addLinkedAsset(LinkedAsset linkedAsset) throws ModelOperationException {
-		if(processedAssets.add(linkedAsset)) {
+		if(processedAssets.add(linkedAsset.getPrimaryRequirePath())) {
 			if (linkedAsset.isRequirable()) {
-				assets.add(linkedAsset);
+				addToAssetMap(assets, linkedAsset);
 			}
 			
 			List<Asset> moduleDependencies = getModuleDependencies(linkedAsset);
@@ -107,7 +112,7 @@ public class BundleSetBuilder {
 				}
 				
 				if (dependantAsset.isRequirable()) {
-					assets.add(dependantAsset);
+					addToAssetMap(assets, dependantAsset);
 				}
 			}
 			
@@ -177,9 +182,9 @@ public class BundleSetBuilder {
 	
 	
 	private void addUnscopedAsset(LinkedAsset asset) throws ModelOperationException {
-		if (assets.add(asset)) {
+		if (addToAssetMap(assets, asset)) {
 			for (Asset dependentAsset : getModuleDependencies(asset)) {
-				assets.add(dependentAsset);
+				addToAssetMap(assets, dependentAsset);
 			}
 		}
 	}
@@ -195,12 +200,12 @@ public class BundleSetBuilder {
 	}
 	
 	
-	private void addAllSourceModuleDependencies(SourceModule sourceModule, List<SourceModule> sourceModules) throws ModelOperationException
+	private void addAllSourceModuleDependencies(SourceModule sourceModule, Map<String,SourceModule> sourceModules) throws ModelOperationException
 	{
 		addAllSourceModuleDependencies(sourceModule, sourceModules, new ArrayList<SourceModule>());
 	}
 	
-	private void addAllSourceModuleDependencies(SourceModule sourceModule, List<SourceModule> sourceModules, List<SourceModule> processedModules) throws ModelOperationException
+	private void addAllSourceModuleDependencies(SourceModule sourceModule, Map<String,SourceModule> sourceModules, List<SourceModule> processedModules) throws ModelOperationException
 	{
 		if (processedModules.contains(sourceModule))
 		{
@@ -210,16 +215,16 @@ public class BundleSetBuilder {
 		
 		for (Asset asset : sourceModule.getDependentAssets(bundlableNode))
 		{
-			if (!sourceModules.contains(asset)) {
+			if (!sourceModules.containsKey(asset.getPrimaryRequirePath())) {
 				if(asset instanceof SourceModule){
 					addAllSourceModuleDependencies((SourceModule)asset, sourceModules, processedModules);
 				}
 			}
 		}
-		sourceModules.add(sourceModule);
+		sourceModules.put(sourceModule.getPrimaryRequirePath(), sourceModule);
 	}
 	
-	private void addBootstrapAndDependencies(List<SourceModule> bootstrappingSourceModules) throws ModelOperationException
+	private void addBootstrapAndDependencies(Map<String,SourceModule> bootstrappingSourceModules) throws ModelOperationException
 	{
 		JsLib boostrapLib = bundlableNode.app().jsLib(BOOTSTRAP_LIB_NAME);
 		for (Asset asset : boostrapLib.assets()) {
@@ -259,6 +264,14 @@ public class BundleSetBuilder {
 			currentDir = currentDir.getParentFile();
 		}
 		return false;
+	}
+
+	private static <AT extends Asset> boolean addToAssetMap(Map<String,AT> map, AT asset) {
+		if (map.containsKey(asset.getPrimaryRequirePath())) {
+			return false;
+		}
+		map.put(asset.getPrimaryRequirePath(), asset);
+		return true;
 	}
 	
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/DefineTimeDependencyGraphCreator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/DefineTimeDependencyGraphCreator.java
@@ -12,22 +12,23 @@ import org.bladerunnerjs.api.SourceModule;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 
 public class DefineTimeDependencyGraphCreator {
-	public static Map<SourceModule, List<SourceModule>> createGraph(BundlableNode bundlableNode, Set<SourceModule> sourceModules, boolean isPreExport) throws ModelOperationException {
-		Map<SourceModule, List<SourceModule>> dependencyGraph = new LinkedHashMap<>();
+	public static Map<String, List<String>> createGraph(BundlableNode bundlableNode, Set<SourceModule> sourceModules, boolean isPreExport) throws ModelOperationException {
+		
+		Map<String, List<String>> dependencyGraph = new LinkedHashMap<>();
 		
 		for(SourceModule sourceModule : sourceModules) {
 			List<Asset> dependentAssets = (isPreExport) ? sourceModule.getPreExportDefineTimeDependentAssets(bundlableNode) : sourceModule.getPostExportDefineTimeDependentAssets(bundlableNode);
-			dependencyGraph.put(sourceModule, extractSourceModules(dependentAssets));
+			dependencyGraph.put(sourceModule.getPrimaryRequirePath(), extractSourceModules(dependentAssets));
 		}
 		
 		return dependencyGraph;
 	}
 	
-	private static List<SourceModule> extractSourceModules(List<Asset> assets){
-		List<SourceModule> sourceModules = new ArrayList<SourceModule>();
+	private static List<String> extractSourceModules(List<Asset> assets){
+		List<String> sourceModules = new ArrayList<String>();
 		for(Asset asset : assets){
 			if(asset instanceof SourceModule){
-				sourceModules.add((SourceModule)asset);
+				sourceModules.add(asset.getPrimaryRequirePath());
 			}
 		}
 		return sourceModules;

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/DefineTimeDependencyGraphCreator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/DefineTimeDependencyGraphCreator.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.bladerunnerjs.api.Asset;
 import org.bladerunnerjs.api.BundlableNode;
@@ -12,19 +11,20 @@ import org.bladerunnerjs.api.SourceModule;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 
 public class DefineTimeDependencyGraphCreator {
-	public static Map<String, List<String>> createGraph(BundlableNode bundlableNode, Set<SourceModule> sourceModules, boolean isPreExport) throws ModelOperationException {
-		
+	
+	public static Map<String, List<String>> createGraph(BundlableNode bundlableNode, Map<String,SourceModule> sourceModules, boolean isPreExport) throws ModelOperationException {
 		Map<String, List<String>> dependencyGraph = new LinkedHashMap<>();
 		
-		for(SourceModule sourceModule : sourceModules) {
+		for (String sourceModuleRequirePath : sourceModules.keySet()) {
+			SourceModule sourceModule = sourceModules.get(sourceModuleRequirePath);
 			List<Asset> dependentAssets = (isPreExport) ? sourceModule.getPreExportDefineTimeDependentAssets(bundlableNode) : sourceModule.getPostExportDefineTimeDependentAssets(bundlableNode);
-			dependencyGraph.put(sourceModule.getPrimaryRequirePath(), extractSourceModules(dependentAssets));
+			dependencyGraph.put(sourceModuleRequirePath, extractSourceRequirePaths(dependentAssets));
 		}
 		
 		return dependencyGraph;
 	}
 	
-	private static List<String> extractSourceModules(List<Asset> assets){
+	private static List<String> extractSourceRequirePaths(List<Asset> assets){
 		List<String> sourceModules = new ArrayList<String>();
 		for(Asset asset : assets){
 			if(asset instanceof SourceModule){
@@ -33,4 +33,5 @@ public class DefineTimeDependencyGraphCreator {
 		}
 		return sourceModules;
 	}
+	
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreator.java
@@ -11,56 +11,61 @@ import org.bladerunnerjs.api.SourceModule;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 
 public class NonCircularTransitivePreExportDependencyGraphCreator {
-	public static Map<SourceModule, List<SourceModule>> createGraph(Map<SourceModule, List<SourceModule>> preExportDependencyGraph, Map<SourceModule, List<SourceModule>> postExportDependencyGraph) throws ModelOperationException {
-		Map<SourceModule, List<SourceModule>> combinedDefineTimeDependencyGraph = new LinkedHashMap<>();
+	
+	public static Map<String, List<String>> createGraph(Map<String,SourceModule> allSourceModules,
+			Map<String, List<String>> preExportDependencyGraph, Map<String, List<String>> postExportDependencyGraph) throws ModelOperationException {
 		
-		for(SourceModule sourceModule : preExportDependencyGraph.keySet()) {
-			List<SourceModule> combinedDefineTimeDependencies = new ArrayList<>(preExportDependencyGraph.get(sourceModule));
-			combinedDefineTimeDependencies.addAll(postExportDependencyGraph.get(sourceModule));
+		
+		Map<String, List<String>> combinedDefineTimeDependencyGraph = new LinkedHashMap<>();
+		
+		for (String sourceModuleRequirePath : preExportDependencyGraph.keySet()) {
+			List<String> combinedDefineTimeDependencies = new ArrayList<>(preExportDependencyGraph.get(sourceModuleRequirePath));
+			combinedDefineTimeDependencies.addAll(postExportDependencyGraph.get(sourceModuleRequirePath));
 			
-			combinedDefineTimeDependencyGraph.put(sourceModule, combinedDefineTimeDependencies);
+			combinedDefineTimeDependencyGraph.put(sourceModuleRequirePath, combinedDefineTimeDependencies);
 		}
 		
-		Map<SourceModule, List<SourceModule>> nonCircularPostExportDependencyGraph = nonCircularPostExportDependencies(postExportDependencyGraph, combinedDefineTimeDependencyGraph);
+		Map<String, List<String>> nonCircularPostExportDependencyGraph = nonCircularPostExportDependencies(allSourceModules, postExportDependencyGraph, combinedDefineTimeDependencyGraph);
 		
 		return growDependencyGraph(preExportDependencyGraph, nonCircularPostExportDependencyGraph);
 	}
 
-	private static Map<SourceModule, List<SourceModule>> nonCircularPostExportDependencies(Map<SourceModule, List<SourceModule>> postExportDependencyGraph, Map<SourceModule, List<SourceModule>> combinedDefineTimeDependencyGraph) {
-		Map<SourceModule, List<SourceModule>> nonCircularPostExportDependencyGraph = new LinkedHashMap<>();
+	private static Map<String, List<String>> nonCircularPostExportDependencies(Map<String,SourceModule> allSourceModules, Map<String, List<String>> postExportDependencyGraph, Map<String, List<String>> combinedDefineTimeDependencyGraph) {
 		
-		for(SourceModule sourceModule : postExportDependencyGraph.keySet()) {
-			List<SourceModule> dependentSourceModules = postExportDependencyGraph.get(sourceModule);
-			List<SourceModule> nonCircularDependentSourceModules = new ArrayList<>();
+		Map<String, List<String>> nonCircularPostExportDependencyGraph = new LinkedHashMap<>();
+		
+		for(String sourceModuleRequirePath : postExportDependencyGraph.keySet()) {
+			SourceModule sourceModule = allSourceModules.get(sourceModuleRequirePath);
+			List<String> dependentSourceModules = postExportDependencyGraph.get(sourceModuleRequirePath);
+			List<String> nonCircularDependentSourceModules = new ArrayList<>();
 			
-			for(SourceModule dependentSourceModule : dependentSourceModules) {
-				if(!reachable(dependentSourceModule, sourceModule, combinedDefineTimeDependencyGraph, new LinkedHashSet<>())) {
-					nonCircularDependentSourceModules.add(dependentSourceModule);
+			for(String dependentSourceModuleRequirePath : dependentSourceModules) {
+				SourceModule dependentSourceModule = allSourceModules.get(dependentSourceModuleRequirePath);
+				if (!reachable(dependentSourceModule, sourceModule, allSourceModules, combinedDefineTimeDependencyGraph, new LinkedHashSet<>())) {
+					nonCircularDependentSourceModules.add(dependentSourceModuleRequirePath);
 				}
 			}
 			
-			nonCircularPostExportDependencyGraph.put(sourceModule, nonCircularDependentSourceModules);
+			nonCircularPostExportDependencyGraph.put(sourceModuleRequirePath, nonCircularDependentSourceModules);
 		}
 		
 		return nonCircularPostExportDependencyGraph;
 	}
 
-	private static boolean reachable(SourceModule fromSourceModule, SourceModule toSourceModule, Map<SourceModule, List<SourceModule>> combinedDefineTimeDependencyGraph, Set<SourceModule> visitedSourceModules) {
+	private static boolean reachable(SourceModule fromSourceModule, SourceModule toSourceModule, 
+			Map<String,SourceModule> allSourceModules, Map<String, List<String>> combinedDefineTimeDependencyGraph, Set<String> visitedSourceModules) {
 		
-		if (!combinedDefineTimeDependencyGraph.containsKey(fromSourceModule)) {
-			throw new RuntimeException("The source module '"+fromSourceModule.getPrimaryRequirePath()+"' does not exist within the 'combinedDefineTimeDependencyGraph'.\n"+
-					"To help debug this issue please add details of the exception and the source module's use to https://github.com/BladeRunnerJS/brjs/issues/1517.");
-		}
-		
-		for(SourceModule dependentSourceModule : combinedDefineTimeDependencyGraph.get(fromSourceModule)) {
-			if(dependentSourceModule == toSourceModule) {
+		for(String dependentSourceModuleRequirePath : combinedDefineTimeDependencyGraph.get(fromSourceModule.getPrimaryRequirePath())) {
+			SourceModule dependentSourceModule = allSourceModules.get(dependentSourceModuleRequirePath);
+			
+			if (dependentSourceModule.getPrimaryRequirePath().equals(toSourceModule.getPrimaryRequirePath())) {
 				return true;
 			}
 			
-			if(!visitedSourceModules.contains(dependentSourceModule)) {
-				visitedSourceModules.add(dependentSourceModule);
+			if(!visitedSourceModules.contains(dependentSourceModule.getPrimaryRequirePath())) {
+				visitedSourceModules.add(dependentSourceModule.getPrimaryRequirePath());
 				
-				if(reachable(dependentSourceModule, toSourceModule, combinedDefineTimeDependencyGraph, visitedSourceModules)) {
+				if(reachable(dependentSourceModule, toSourceModule, allSourceModules, combinedDefineTimeDependencyGraph, visitedSourceModules)) {
 					return true;
 				}
 			}
@@ -69,17 +74,18 @@ public class NonCircularTransitivePreExportDependencyGraphCreator {
 		return false;
 	}
 
-	private static Map<SourceModule, List<SourceModule>> growDependencyGraph(Map<SourceModule, List<SourceModule>> dependencyGraph, Map<SourceModule, List<SourceModule>> nonCircularPostExportDependencyGraph) {
+	private static Map<String, List<String>> growDependencyGraph(Map<String, List<String>> dependencyGraph, Map<String, List<String>> nonCircularPostExportDependencyGraph) {
+		
 		boolean progressMade;
 		
 		do {
 			progressMade = false;
 			
-			for(SourceModule sourceModule : nonCircularPostExportDependencyGraph.keySet()) {
-				for(SourceModule dependentSourceModule : nonCircularPostExportDependencyGraph.get(sourceModule)) {
-					if(!dependencyGraph.get(sourceModule).contains(dependentSourceModule)) {
+			for(String sourceModuleRequirePath : nonCircularPostExportDependencyGraph.keySet()) {
+				for(String dependentSourceModuleRequirePath : nonCircularPostExportDependencyGraph.get(sourceModuleRequirePath)) {
+					if(!dependencyGraph.get(sourceModuleRequirePath).contains(dependentSourceModuleRequirePath)) {
 						progressMade = true;
-						dependencyGraph.get(sourceModule).add(dependentSourceModule);
+						dependencyGraph.get(sourceModuleRequirePath).add(dependentSourceModuleRequirePath);
 					}
 				}
 			}

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/SourceModuleDependencyOrderCalculator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/SourceModuleDependencyOrderCalculator.java
@@ -13,20 +13,22 @@ import org.bladerunnerjs.api.model.exception.CircularDependencyException;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 
 public class SourceModuleDependencyOrderCalculator {
-	public static List<SourceModule> getOrderedSourceModules(BundlableNode bundlableNode, Map<String,SourceModule> bootstrappingSourceModules, Map<String,SourceModule> allSourceModules) throws ModelOperationException {
+	
+	public static List<SourceModule> getOrderedSourceModules(BundlableNode bundlableNode, AssetMap<SourceModule> bootstrappingSourceModules, AssetMap<SourceModule> allSourceModules) throws ModelOperationException {
 		
-		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(bundlableNode, new LinkedHashSet<>(allSourceModules.values()), true);
-		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(bundlableNode, new LinkedHashSet<>(allSourceModules.values()), false);
+		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(bundlableNode, allSourceModules.internalMap, true);
+		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(bundlableNode, allSourceModules.internalMap, false);
+		
 		Map<String, List<String>> sourceModuleDependencies = 
-				NonCircularTransitivePreExportDependencyGraphCreator.createGraph(allSourceModules, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
+				NonCircularTransitivePreExportDependencyGraphCreator.createGraph(allSourceModules.internalMap, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
 		
 		Map<String,SourceModule> orderedSourceModules = new LinkedHashMap<>();
 		Set<String> metDependencies = new LinkedHashSet<>();		
 		
-		orderedSourceModules.putAll(bootstrappingSourceModules);
+		orderedSourceModules.putAll(bootstrappingSourceModules.internalMap);
 		metDependencies.addAll(bootstrappingSourceModules.keySet());
 		
-		Map<String,SourceModule> unorderedSourceModules = new LinkedHashMap<>(allSourceModules);
+		Map<String,SourceModule> unorderedSourceModules = new LinkedHashMap<>(allSourceModules.internalMap);
 		
 		while (!unorderedSourceModules.isEmpty()) {
 			Map<String,SourceModule> unprocessedSourceModules = new LinkedHashMap<>();
@@ -62,4 +64,5 @@ public class SourceModuleDependencyOrderCalculator {
 		}
 		return true;
 	}
+	
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/utility/SourceModuleDependencyOrderCalculator.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/utility/SourceModuleDependencyOrderCalculator.java
@@ -20,7 +20,7 @@ public class SourceModuleDependencyOrderCalculator {
 		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(bundlableNode, allSourceModules.internalMap, false);
 		
 		Map<String, List<String>> sourceModuleDependencies = 
-				NonCircularTransitivePreExportDependencyGraphCreator.createGraph(allSourceModules.internalMap, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
+				NonCircularTransitivePreExportDependencyGraphCreator.createGraph(preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
 		
 		Map<String,SourceModule> orderedSourceModules = new LinkedHashMap<>();
 		Set<String> metDependencies = new LinkedHashSet<>();		

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/DependencyGraph.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/DependencyGraph.java
@@ -1,6 +1,5 @@
 package org.bladerunnerjs.utility;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -9,23 +8,16 @@ import org.bladerunnerjs.api.SourceModule;
 import com.google.common.base.Joiner;
 
 public class DependencyGraph {
-	private Map<SourceModule, List<SourceModule>> graph;
+	
+	private Map<String, List<String>> graph;
+	Map<String,SourceModule> allSourceModules;
 
-	public DependencyGraph(Map<SourceModule, List<SourceModule>> graph) {
+	public DependencyGraph(Map<String, List<String>> graph) {
 		this.graph = graph;
 	}
 
 	public String dependenciesOf(FakeSourceModule sourceModule) {
-		return Joiner.on(", ").join(requirePaths(graph.get(sourceModule)));
+		return Joiner.on(", ").join(graph.get(sourceModule.getPrimaryRequirePath()));
 	}
 	
-	private List<String> requirePaths(List<SourceModule> sourceModules) {
-		List<String> requirePaths = new ArrayList<>();
-		
-		for(SourceModule sourceModule : sourceModules) {
-			requirePaths.add(sourceModule.getPrimaryRequirePath());
-		}
-		
-		return requirePaths;
-	}
 }

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
@@ -3,7 +3,6 @@ package org.bladerunnerjs.utility;
 import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import org.bladerunnerjs.api.SourceModule;
@@ -22,8 +21,8 @@ public class NonCircularTransitivePreExportDependencyGraphCreatorTest {
 			sourceModules.put(module.getPrimaryRequirePath(), module);
 		}
 		
-		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, new LinkedHashSet<>(sourceModules.values()), false);
-		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, new LinkedHashSet<>(sourceModules.values()), true);
+		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, false);
+		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, true);
 		Map<String, List<String>> nonCircularTransitivePreExportDependencyGraph = NonCircularTransitivePreExportDependencyGraphCreator.createGraph(
 				sourceModules, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
 		

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
@@ -2,10 +2,10 @@ package org.bladerunnerjs.utility;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Set;
-
+import java.util.List;
+import java.util.Map;
 import org.bladerunnerjs.api.SourceModule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,9 +17,17 @@ public class NonCircularTransitivePreExportDependencyGraphCreatorTest {
 	private FakeSourceModule d = new FakeSourceModule("d");
 	
 	private DependencyGraph dependencyGraph(SourceModule... sourceModuleArray) throws Exception {
-		Set<SourceModule> sourceModules = new LinkedHashSet<>(Arrays.asList(sourceModuleArray));
-		return new DependencyGraph(NonCircularTransitivePreExportDependencyGraphCreator.createGraph(
-			DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, true), DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, false)));
+		Map<String,SourceModule> sourceModules = new LinkedHashMap<>();
+		for (SourceModule module : sourceModuleArray) {
+			sourceModules.put(module.getPrimaryRequirePath(), module);
+		}
+		
+		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, new LinkedHashSet<>(sourceModules.values()), false);
+		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, new LinkedHashSet<>(sourceModules.values()), true);
+		Map<String, List<String>> nonCircularTransitivePreExportDependencyGraph = NonCircularTransitivePreExportDependencyGraphCreator.createGraph(
+				sourceModules, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
+		
+		return new DependencyGraph(nonCircularTransitivePreExportDependencyGraph);
 		
 	}
 	

--- a/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
+++ b/brjs-core/src/test/java/org/bladerunnerjs/utility/NonCircularTransitivePreExportDependencyGraphCreatorTest.java
@@ -24,7 +24,7 @@ public class NonCircularTransitivePreExportDependencyGraphCreatorTest {
 		Map<String, List<String>> postExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, false);
 		Map<String, List<String>> preExportDefineTimeDependencyGraph = DefineTimeDependencyGraphCreator.createGraph(null, sourceModules, true);
 		Map<String, List<String>> nonCircularTransitivePreExportDependencyGraph = NonCircularTransitivePreExportDependencyGraphCreator.createGraph(
-				sourceModules, preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
+				preExportDefineTimeDependencyGraph, postExportDefineTimeDependencyGraph);
 		
 		return new DependencyGraph(nonCircularTransitivePreExportDependencyGraph);
 		


### PR DESCRIPTION
Change dependency analysis and graph creators to use Maps of require path to SourceModule so we don't reply on the `hashCode` method to be overridden to ensure Lists and Sets work properly. Fixes NPE issue (#1517)

<!---
@huboard:{"order":811.0,"milestone_order":1624,"custom_state":""}
-->
