### PR TITLE
LocalisedAmountParser will now only convert values with a token such as K or M

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
@@ -9,15 +9,16 @@ var Parser = require('br/parsing/Parser');
  * @class
  * @alias module:br/parsing/LocalisedAmountParser
  * @implements module:br/parsing/Parser
- * 
+ *
  * @classdesc
- * Parses an amount containing a thousands, millions or billions token into a number.
- * 
+ * Parses an amount containing a thousands, millions or billions token into a number. If no token is present, it
+ * returns the original value
+ *
  * <p><code>LocalisedAmountParser</code> is typically used with Presenter, but can be invoked programmatically
  * as in the following example which evaluates to "4900000":</p>
- * 
+ *
  * <pre>LocalisedAmountParser.parse("4.9MM", {})</pre>
- * 
+ *
  * See {@link module:br/formatting/AmountFormatter} for the complementary formatter.
  */
 function LocalisedAmountParser() {}
@@ -28,7 +29,7 @@ topiarist.implement(LocalisedAmountParser, Parser);
  * Parses an amount containing a thousands, millions or billions token into a number.
  *
  * If the amount does not match, then null is returned.
- * 
+ *
  * <p>
  * Attribute Options:
  * </p>
@@ -46,30 +47,31 @@ topiarist.implement(LocalisedAmountParser, Parser);
  *
  * @param {Variant} sValue  the amount with tokens
  * @param {Object} mAttributes  the map of attributes.
- * @return  the numeric amount, or null if the value was not recognized.
+ * @return  the numeric amount if converted, the original string if not conversion required or null if the value
+ * was not recognized.
  * @type  String
  */
-LocalisedAmountParser.prototype.parse = function(sValue, mAttributes) 
+LocalisedAmountParser.prototype.parse = function(sValue, mAttributes)
 {
 	if(typeof sValue != "string")
 	{
 		return sValue;
 	}
-	
+
 	if(sValue.length < 1)
 	{
 		return null;
 	}
-	
+
 	var nMultiplier = 1;
 	var sLastChar = sValue.charAt( (sValue.length - 1));
 	if(isNaN(sLastChar))
 	{
 		nMultiplier = this._getShortcutMultiplier(sLastChar);
-		
+
 		if(nMultiplier != null)
 		{
-			sValue = sValue.substr(0, (sValue.length - 1));		
+			sValue = sValue.substr(0, (sValue.length - 1));
 		}
 		else
 		{
@@ -77,17 +79,22 @@ LocalisedAmountParser.prototype.parse = function(sValue, mAttributes)
 		}
 	}
 
-	var oTranslator = require("br/I18n").getTranslator();
-	var sValue = oTranslator.parseNumber(sValue);
-	
-	if(!sValue)
-	{
-		return null;
+	if (nMultiplier !== 1) {
+		var oTranslator = require("br/I18n").getTranslator();
+		var sValue = oTranslator.parseNumber(sValue);
+
+		if(!sValue)
+		{
+			return null;
+		}
+
+		var nResult =  sValue * nMultiplier; //coerces the result to a number
+
+		return nResult;
+	} else {
+		return sValue;
 	}
-	
-	var nResult =  sValue * nMultiplier; //coerces the result to a number
-	
-	return nResult;
+
 };
 
 LocalisedAmountParser.prototype.isSingleUseParser = function() {
@@ -98,15 +105,15 @@ LocalisedAmountParser.prototype._getShortcutMultiplier = function(sShortcutSymbo
 {
 	var sToken = "br.parsing.number.formatting.multiplier." + sShortcutSymbol.toLowerCase();
 	var oTranslator = require("br/I18n").getTranslator();
-	if (oTranslator.tokenExists(sToken)) 
+	if (oTranslator.tokenExists(sToken))
 	{
 		var multiplier = oTranslator.getMessage(sToken);
-		if (!isNaN(multiplier)) 
+		if (!isNaN(multiplier))
 		{
 			return multiplier*1;
 		}
 	}
-	
+
 	return null;
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
@@ -47,34 +47,27 @@ topiarist.implement(LocalisedAmountParser, Parser);
  *
  * @param {Variant} sValue  the amount with tokens
  * @param {Object} mAttributes  the map of attributes.
- * @return  the numeric amount if converted, the original string if not conversion required or null if the value
+ * @return  the numeric amount if converted, the original string if no conversion required or null if the value
  * was not recognized.
  * @type  String
  */
-LocalisedAmountParser.prototype.parse = function(sValue, mAttributes)
-{
-	if(typeof sValue != "string")
-	{
+LocalisedAmountParser.prototype.parse = function(sValue, mAttributes) {
+	if(typeof sValue != "string") {
 		return sValue;
 	}
 
-	if(sValue.length < 1)
-	{
+	if(sValue.length < 1) {
 		return null;
 	}
 
 	var nMultiplier = 1;
 	var sLastChar = sValue.charAt( (sValue.length - 1));
-	if(isNaN(sLastChar))
-	{
+	if(isNaN(sLastChar)) {
 		nMultiplier = this._getShortcutMultiplier(sLastChar);
 
-		if(nMultiplier != null)
-		{
+		if(nMultiplier != null)	{
 			sValue = sValue.substr(0, (sValue.length - 1));
-		}
-		else
-		{
+		} else {
 			return null;
 		}
 	}
@@ -83,8 +76,7 @@ LocalisedAmountParser.prototype.parse = function(sValue, mAttributes)
 		var oTranslator = require("br/I18n").getTranslator();
 		var sValue = oTranslator.parseNumber(sValue);
 
-		if(!sValue)
-		{
+		if(!sValue)	{
 			return null;
 		}
 
@@ -101,15 +93,12 @@ LocalisedAmountParser.prototype.isSingleUseParser = function() {
 	return false;
 };
 
-LocalisedAmountParser.prototype._getShortcutMultiplier = function(sShortcutSymbol)
-{
+LocalisedAmountParser.prototype._getShortcutMultiplier = function(sShortcutSymbol) {
 	var sToken = "br.parsing.number.formatting.multiplier." + sShortcutSymbol.toLowerCase();
 	var oTranslator = require("br/I18n").getTranslator();
-	if (oTranslator.tokenExists(sToken))
-	{
+	if (oTranslator.tokenExists(sToken)) {
 		var multiplier = oTranslator.getMessage(sToken);
-		if (!isNaN(multiplier))
-		{
+		if (!isNaN(multiplier))	{
 			return multiplier*1;
 		}
 	}

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedAmountParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedAmountParserTest.js
@@ -10,38 +10,45 @@
 
 	LocalisedAmountParserTest.prototype.test_testParseK = function() {
 		var sValue = "5k";
-		assertEquals(5000, this.oParser.parse(sValue, this.mAttributes));
-		var sStreamValue = "5K";
-		assertEquals(5000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5000, this.oParser.parse(sValue, this.mAttributes));
+		sValue = "5K";
+		assertSame(5000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseMillion = function() {
 		var sValue = "5m";
-		assertEquals(5000000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5000000, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "5M";
-		assertEquals(5000000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5000000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseBillion = function() {
 		var sValue = "5b";
-		assertEquals(5000000000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5000000000, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "5B";
-		assertEquals(5000000000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5000000000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseDecimal = function() {
 		var sValue = "1.2345K";
-		assertEquals(1234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(1234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "1.2345";
-		assertEquals(1.2345, this.oParser.parse(sValue, this.mAttributes));
+		assertSame("1.2345", this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.2345K";
-		assertEquals(234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.2345";
-		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
+		assertSame("0.2345", this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345K";
-		assertEquals(234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345";
-		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(".2345", this.oParser.parse(sValue, this.mAttributes));
+	};
+
+	LocalisedAmountParserTest.prototype.test_testParseTrailingZero = function() {
+		var sValue = "123.0";
+		assertSame("123.0", this.oParser.parse(sValue, this.mAttributes));
+		var sValue = "123.0k";
+		assertSame(123000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 
@@ -49,39 +56,39 @@
 		this.oParser = new LocalisedAmountParser();
 
 		var sValue = "1.25l";
-		assertEquals(62.5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(62.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "1.25x";
-		assertEquals(12.5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(12.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.5X";
-		assertEquals(5, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.23c";
-		assertEquals(23, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(23, this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345";
-		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(".2345", this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseDecimalPlusShortcut = function()
 	{
 		var sValue = "3.k";
-		assertEquals(3000, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(3000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testInvalidNumberToNull = function()
 	{
 		var sValue = ".";
-		assertEquals(null, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(null, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "a";
-		assertEquals(null, this.oParser.parse(sValue, this.mAttributes));
+		assertSame(null, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testIgnoreComma = function()
 	{
 		var sValue = "1,234";
-		assertEquals(1234, this.oParser.parse(sValue, this.mAttributes));
+		assertSame("1,234", this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_toString = function()
 	{
-		assertEquals("string", typeof this.oParser.toString() );
+		assertSame("string", typeof this.oParser.toString() );
 	};
 })();


### PR DESCRIPTION


<!---
@huboard:{"order":813.0,"milestone_order":1627,"custom_state":""}
-->
