### PR TITLE
improve ErrorMonitor with its own hasError property #1637

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/util/ErrorMonitor.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/src/br/presenter/util/ErrorMonitor.js
@@ -2,6 +2,7 @@
 
 var ToolTipField = require('br/presenter/node/ToolTipField');
 var PropertyHelper = require('br/presenter/property/PropertyHelper');
+var EditableProperty = require('br/presenter/property/EditableProperty');
 var Errors = require('br/Errors');
 var ToolTipNode = require('br/presenter/node/ToolTipNode');
 
@@ -30,6 +31,8 @@ function ErrorMonitor(oTooltipNode) {
 	this.oTooltipNode = oTooltipNode;
 
 	this.m_pErrorStack = [];
+
+	this.hasError = new EditableProperty(false);
 }
 
 /**
@@ -79,7 +82,9 @@ ErrorMonitor.prototype.monitorField = function(oField) {
 
 	var oTicketErrorProperty = this;
 	var fValidationSuccessHandler = function() {
-		if (!this.hasError.getValue()) {
+		if (this.hasError.getValue() === true && oField.failureMessage.getValue() !== '') {
+			oTicketErrorProperty._addError(oField);
+		} else {
 			oTicketErrorProperty._removeError(this);
 		}
 	};
@@ -115,6 +120,7 @@ ErrorMonitor.prototype.removeAllErrors = function() {
 
 ErrorMonitor.prototype._addError = function(oField) {
 	this._removeFromStack(oField);
+	this.hasError.setValue(true);
 
 	var sFailureMessage = oField.failureMessage.getValue();
 	this.m_pErrorStack.push({
@@ -182,6 +188,7 @@ ErrorMonitor.prototype._notifyObserversOfErrorChange = function() {
  */
 ErrorMonitor.prototype._removeLastError = function() {
 	this.oTooltipNode.setMessage('');
+	this.hasError.setValue(false);
 };
 
 /**
@@ -189,7 +196,10 @@ ErrorMonitor.prototype._removeLastError = function() {
  * @private
  */
 ErrorMonitor.prototype._updateErrorMessage = function() {
-	this.oTooltipNode.setMessage(this._getNextErrorMessage());
+	var oErrorMessage = this._getNextErrorMessage();
+	if (oErrorMessage) {
+		this.oTooltipNode.setMessage(oErrorMessage);
+	}
 };
 
 /**
@@ -239,7 +249,9 @@ ErrorMonitor.prototype._addTooltipToTopOfStack = function() {
  * @private
  */
 ErrorMonitor.prototype._addTooltipTo = function(oField) {
-	oField.tooltipClassName.setValue(this.oTooltipNode.getTooltipClassName());
+	if (oField.failureMessage.getValue() !== '') {
+		oField.tooltipClassName.setValue(this.oTooltipNode.getTooltipClassName());
+	}
 };
 
 /**

--- a/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/util/ErrorMonitorTests.js
+++ b/brjs-sdk/sdk/libs/javascript/br-presenter/test-unit/tests/br/presenter/util/ErrorMonitorTests.js
@@ -54,6 +54,33 @@
 
 			//when
 			assertFails("A ToolTipField must be passed in.", function() { errorMonitor.monitorField(field) });
+		},
+
+		"test if hasError is set when any of the fields has error": function() {
+			//given
+			var toolTipField1 = new ToolTipField();
+			var toolTipField2 = new ToolTipField();
+
+			errorMonitor.hasError = spy(errorMonitor.hasError);
+
+			//when
+			errorMonitor.addErrorListeners([toolTipField1, toolTipField2]);
+			toolTipField2.hasError.setValue(true);
+
+			//then
+			assertTrue(errorMonitor.hasError.getValue(), true);
+		},
+
+		"test if hasError isn't set when field hasn't error": function() {
+			//given
+			var toolTipField = new ToolTipField();
+			errorMonitor.hasError = spy(errorMonitor.hasError);
+
+			//when
+			errorMonitor.addErrorListeners([toolTipField]);
+
+			//then
+			assertFalse(errorMonitor.hasError.getValue(), false);
 		}
 
 


### PR DESCRIPTION
Improved ErrorMonitor with its own hasError property which indicates if any of the associated fields has error.
Fixed **_addTooltipTo** private method to show tooltips only if it has failureMessage.

<!---
@huboard:{"order":797.0,"milestone_order":1638,"custom_state":""}
-->
