### PR TITLE
Revert "LocalisedAmountParser will now only convert values with a token such as K or M"

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/src/LocalisedAmountParser.js
@@ -9,16 +9,15 @@ var Parser = require('br/parsing/Parser');
  * @class
  * @alias module:br/parsing/LocalisedAmountParser
  * @implements module:br/parsing/Parser
- *
+ * 
  * @classdesc
- * Parses an amount containing a thousands, millions or billions token into a number. If no token is present, it
- * returns the original value
- *
+ * Parses an amount containing a thousands, millions or billions token into a number.
+ * 
  * <p><code>LocalisedAmountParser</code> is typically used with Presenter, but can be invoked programmatically
  * as in the following example which evaluates to "4900000":</p>
- *
+ * 
  * <pre>LocalisedAmountParser.parse("4.9MM", {})</pre>
- *
+ * 
  * See {@link module:br/formatting/AmountFormatter} for the complementary formatter.
  */
 function LocalisedAmountParser() {}
@@ -29,7 +28,7 @@ topiarist.implement(LocalisedAmountParser, Parser);
  * Parses an amount containing a thousands, millions or billions token into a number.
  *
  * If the amount does not match, then null is returned.
- *
+ * 
  * <p>
  * Attribute Options:
  * </p>
@@ -47,62 +46,67 @@ topiarist.implement(LocalisedAmountParser, Parser);
  *
  * @param {Variant} sValue  the amount with tokens
  * @param {Object} mAttributes  the map of attributes.
- * @return  the numeric amount if converted, the original string if no conversion required or null if the value
- * was not recognized.
+ * @return  the numeric amount, or null if the value was not recognized.
  * @type  String
  */
-LocalisedAmountParser.prototype.parse = function(sValue, mAttributes) {
-	if(typeof sValue != "string") {
+LocalisedAmountParser.prototype.parse = function(sValue, mAttributes) 
+{
+	if(typeof sValue != "string")
+	{
 		return sValue;
 	}
-
-	if(sValue.length < 1) {
+	
+	if(sValue.length < 1)
+	{
 		return null;
 	}
-
+	
 	var nMultiplier = 1;
 	var sLastChar = sValue.charAt( (sValue.length - 1));
-	if(isNaN(sLastChar)) {
+	if(isNaN(sLastChar))
+	{
 		nMultiplier = this._getShortcutMultiplier(sLastChar);
-
-		if(nMultiplier != null)	{
-			sValue = sValue.substr(0, (sValue.length - 1));
-		} else {
+		
+		if(nMultiplier != null)
+		{
+			sValue = sValue.substr(0, (sValue.length - 1));		
+		}
+		else
+		{
 			return null;
 		}
 	}
 
-	if (nMultiplier !== 1) {
-		var oTranslator = require("br/I18n").getTranslator();
-		var sValue = oTranslator.parseNumber(sValue);
-
-		if(!sValue)	{
-			return null;
-		}
-
-		var nResult =  sValue * nMultiplier; //coerces the result to a number
-
-		return nResult;
-	} else {
-		return sValue;
+	var oTranslator = require("br/I18n").getTranslator();
+	var sValue = oTranslator.parseNumber(sValue);
+	
+	if(!sValue)
+	{
+		return null;
 	}
-
+	
+	var nResult =  sValue * nMultiplier; //coerces the result to a number
+	
+	return nResult;
 };
 
 LocalisedAmountParser.prototype.isSingleUseParser = function() {
 	return false;
 };
 
-LocalisedAmountParser.prototype._getShortcutMultiplier = function(sShortcutSymbol) {
+LocalisedAmountParser.prototype._getShortcutMultiplier = function(sShortcutSymbol)
+{
 	var sToken = "br.parsing.number.formatting.multiplier." + sShortcutSymbol.toLowerCase();
 	var oTranslator = require("br/I18n").getTranslator();
-	if (oTranslator.tokenExists(sToken)) {
+	if (oTranslator.tokenExists(sToken)) 
+	{
 		var multiplier = oTranslator.getMessage(sToken);
-		if (!isNaN(multiplier))	{
+		if (!isNaN(multiplier)) 
+		{
 			return multiplier*1;
 		}
 	}
-
+	
 	return null;
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedAmountParserTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-parsing/test-unit/tests/LocalisedAmountParserTest.js
@@ -10,45 +10,38 @@
 
 	LocalisedAmountParserTest.prototype.test_testParseK = function() {
 		var sValue = "5k";
-		assertSame(5000, this.oParser.parse(sValue, this.mAttributes));
-		sValue = "5K";
-		assertSame(5000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5000, this.oParser.parse(sValue, this.mAttributes));
+		var sStreamValue = "5K";
+		assertEquals(5000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseMillion = function() {
 		var sValue = "5m";
-		assertSame(5000000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5000000, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "5M";
-		assertSame(5000000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5000000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseBillion = function() {
 		var sValue = "5b";
-		assertSame(5000000000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5000000000, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "5B";
-		assertSame(5000000000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5000000000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseDecimal = function() {
 		var sValue = "1.2345K";
-		assertSame(1234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(1234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "1.2345";
-		assertSame("1.2345", this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(1.2345, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.2345K";
-		assertSame(234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.2345";
-		assertSame("0.2345", this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345K";
-		assertSame(234.5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(234.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345";
-		assertSame(".2345", this.oParser.parse(sValue, this.mAttributes));
-	};
-
-	LocalisedAmountParserTest.prototype.test_testParseTrailingZero = function() {
-		var sValue = "123.0";
-		assertSame("123.0", this.oParser.parse(sValue, this.mAttributes));
-		var sValue = "123.0k";
-		assertSame(123000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 
@@ -56,39 +49,39 @@
 		this.oParser = new LocalisedAmountParser();
 
 		var sValue = "1.25l";
-		assertSame(62.5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(62.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "1.25x";
-		assertSame(12.5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(12.5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.5X";
-		assertSame(5, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(5, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "0.23c";
-		assertSame(23, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(23, this.oParser.parse(sValue, this.mAttributes));
 		sValue = ".2345";
-		assertSame(".2345", this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(0.2345, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testParseDecimalPlusShortcut = function()
 	{
 		var sValue = "3.k";
-		assertSame(3000, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(3000, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testInvalidNumberToNull = function()
 	{
 		var sValue = ".";
-		assertSame(null, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(null, this.oParser.parse(sValue, this.mAttributes));
 		sValue = "a";
-		assertSame(null, this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(null, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_testIgnoreComma = function()
 	{
 		var sValue = "1,234";
-		assertSame("1,234", this.oParser.parse(sValue, this.mAttributes));
+		assertEquals(1234, this.oParser.parse(sValue, this.mAttributes));
 	};
 
 	LocalisedAmountParserTest.prototype.test_toString = function()
 	{
-		assertSame("string", typeof this.oParser.toString() );
+		assertEquals("string", typeof this.oParser.toString() );
 	};
 })();


### PR DESCRIPTION
Reverts BladeRunnerJS/brjs#1627
unfixes #1626