### PR TITLE
fix: Change br-bootstrap exports to null

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-bootstrap/thirdparty-lib.manifest
+++ b/brjs-sdk/sdk/libs/javascript/br-bootstrap/thirdparty-lib.manifest
@@ -1,3 +1,3 @@
 depends: browser-modules, br-shims
-exports: "{}"
+exports: null
 js: bootstrap.js

--- a/brjs-sdk/sdk/libs/javascript/browser-modules/thirdparty-lib.manifest
+++ b/brjs-sdk/sdk/libs/javascript/browser-modules/thirdparty-lib.manifest
@@ -1,2 +1,2 @@
 js: browser-modules.js, install.js
-exports: '{}'
+exports: null 

--- a/brjs-sdk/sdk/libs/javascript/jstestdriverextensions/thirdparty-lib.manifest
+++ b/brjs-sdk/sdk/libs/javascript/jstestdriverextensions/thirdparty-lib.manifest
@@ -1,3 +1,3 @@
 depends : mock4js
 js : ApiProtector.js, caplinjsunit-to-jstestdriver.js, abnl.js
-exports: "{}"
+exports: null

--- a/brjs-sdk/sdk/libs/javascript/jsunitextensions/thirdparty-lib.manifest
+++ b/brjs-sdk/sdk/libs/javascript/jsunitextensions/thirdparty-lib.manifest
@@ -1,2 +1,2 @@
 js : jsUnitExtensions.js, Clock.js
-exports: "{}"
+exports: null


### PR DESCRIPTION
Exporting an object literal caused issues for the brjs-app-converter.

<!---
@huboard:{"order":1654.0,"milestone_order":1654,"custom_state":""}
-->
