### PR TITLE
refactor: Rename alias!$data to alias!$aliases-data

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingOfBladeSource.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingOfBladeSource.java
@@ -9,6 +9,7 @@ import org.bladerunnerjs.api.model.exception.OutOfScopeRequirePathException;
 import org.bladerunnerjs.api.model.exception.UnresolvableRequirePathException;
 import org.bladerunnerjs.api.model.exception.request.ContentProcessingException;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.utility.BundleSetBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -373,7 +374,7 @@ public class AspectBundlingOfBladeSource extends SpecTest {
 	@Test
 	public void badRequiresAreNotLoggedForNoneScopeEnforcedSourceModules() throws Exception {
 		given(aspect).indexPageRequires("appns/b1/Blade1Class")
-    		.and(blade1InDefaultBladeset).classRequires("Blade1Class", "alias!$data")
+    		.and(blade1InDefaultBladeset).classRequires("Blade1Class", AliasDataSourceModule.PRIMARY_REQUIRE_PATH)
     		.and(logging).enabled();
     	when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
     	then(logging).doesNotContainWarnMessage(BundleSetBuilder.INVALID_REQUIRE_MSG);

--- a/brjs-sdk/sdk/libs/javascript/br/src/br/AliasRegistry.js
+++ b/brjs-sdk/sdk/libs/javascript/br/src/br/AliasRegistry.js
@@ -7,4 +7,4 @@ var AliasRegistryClass = require('br/AliasRegistryClass');
 /**
  * @type module:br/AliasRegistryClass
  */
-module.exports = new AliasRegistryClass(require('alias!$data'));
+module.exports = new AliasRegistryClass(require('alias!$aliases-data'));

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/plugins/require/AliasDataSourceModule.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/plugins/require/AliasDataSourceModule.java
@@ -16,7 +16,7 @@ import org.bladerunnerjs.plugin.bundlers.commonjs.CommonJsSourceModule;
 
 public class AliasDataSourceModule implements CommonJsSourceModule {
 	private final BundlableNode bundlableNode;
-	public static final String PRIMARY_REQUIRE_PATH = "alias!$data"; 
+	public static final String PRIMARY_REQUIRE_PATH = "alias!$aliases-data"; 
 
 	public AliasDataSourceModule(BundlableNode bundlableNode) {
 		this.bundlableNode = bundlableNode;

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/aliasing/AliasAndServiceBundlingTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/aliasing/AliasAndServiceBundlingTest.java
@@ -18,6 +18,7 @@ import org.bladerunnerjs.plugin.bundlers.aliasing.AliasesReader;
 import org.bladerunnerjs.plugin.bundlers.aliasing.AmbiguousAliasException;
 import org.bladerunnerjs.plugin.bundlers.aliasing.IncompleteAliasException;
 import org.bladerunnerjs.plugin.bundlers.aliasing.UnresolvableAliasException;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.utility.FileUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -336,7 +337,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
 	@Test
 	public void theAliasBlobIsEmptyIfNoAliasesAreUsed() throws Exception
 	{
-		given(aspect).classRequires("appns/Class1", "alias!$data")
+		given(aspect).classRequires("appns/Class1", AliasDataSourceModule.PRIMARY_REQUIRE_PATH)
             .and(aspectAliasesFile).hasAlias("the-alias", "appns.Class1")
             .and(aspect).indexPageRefersTo("appns.Class1");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
@@ -346,7 +347,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
 	@Test
 	public void theAliasBlobContainsAClassReferencedByAlias() throws Exception
 	{
-		given(aspect).classRequires("appns/Class1", "alias!$data")
+		given(aspect).classRequires("appns/Class1", AliasDataSourceModule.PRIMARY_REQUIRE_PATH)
             .and(aspectAliasesFile).hasAlias("the-alias", "appns.Class1")
             .and(aspect).indexPageHasAliasReferences("the-alias");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
@@ -564,7 +565,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).hasClass("appns.ServiceClass")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
 			.and(response).containsText("define('alias!some.service'");
 	}
 
@@ -577,7 +578,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).classFileHasContent("appns.App", "ServiceRegistry.getService('some.service')")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
 			.and(response).containsText("define('alias!some.service'");
 	}
 
@@ -590,7 +591,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).classFileHasContent("appns.App", "ServiceRegistry.getService('br.service')")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
 			.and(response).containsText("define('alias!br.service'");
 	}
 
@@ -604,7 +605,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).classFileHasContent("appns.App", "ServiceRegistry.getService('br.service')")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
 			.and(response).containsText("define('alias!br.service'");
 	}
 
@@ -621,7 +622,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).classFileHasContent("appns.App", "otherBrLib.ServiceUser();")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
             .and(response).containsText("define('alias!lib.service'")
             .and(response).containsText("otherBrLib.ServiceUser();");
 	}
@@ -640,7 +641,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
             .and(aspect).classFileHasContent("appns.App", "otherBrLib.ServiceUser();")
             .and(aspect).indexPageRefersTo("appns.App");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
             .and(response).containsText("define('alias!lib.service'")
             .and(response).containsText("otherBrLib.ServiceUser();");
 	}
@@ -663,7 +664,7 @@ public class AliasAndServiceBundlingTest extends SpecTest
 		brLibAliasDefinitionsFile = new AliasDefinitionsFileBuilder(this, aliasDefinitionsFile(brLib, "resources"));
 		given(brLocaleLib).classFileHasContent("switcher", "require('service!br.locale-switcher').switchLocale();")
     		.and(servicesLib).classFileHasContent("br/ServiceRegistry", "require('./AliasRegistry');")
-    		.and(servicesLib).classFileHasContent("br/AliasRegistry", "require('alias!$data');")
+    		.and(servicesLib).classFileHasContent("br/AliasRegistry", "require('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "');")
 			.and(brLib).hasClasses("br/services/LocaleSwitcher")
 			.and(brLib).classFileHasContent("br/services/BRLocaleLoadingSwitcher", "require('br/services/LocaleSwitcher');")
 			.and(brLib).classFileHasContent("br/services/BRLocaleForwardingSwitcher", "require('br/services/LocaleSwitcher');")
@@ -1026,13 +1027,13 @@ public class AliasAndServiceBundlingTest extends SpecTest
 	
 	@Test
 	public void testPackBundlesCanBeCreatedForAspectDefaultTechTestsWhereAliasRegistryIsUsed() throws Exception {
-		given(aspect).classRequires("appns/Class1", "alias!$data")
+		given(aspect).classRequires("appns/Class1", AliasDataSourceModule.PRIMARY_REQUIRE_PATH)
 			.and( aspect.testType("unit").defaultTestTech() ).hasNamespacedJsPackageStyle()
 			.and( aspect.testType("unit").defaultTestTech() ).testRefersTo("pkg/test.js", "appns.Class1")
 			.and( aspect.testType("unit").defaultTestTech() ).containsResourceFileWithContents("en.properties", "appns.prop=val")
 			.and(sdkLib).hasClass("br/AliasRegistry");
 		when( aspect.testType("unit").defaultTestTech() ).requestReceivedInDev("js/dev/combined/bundle.js", response);
-		then(response).containsText("define('alias!$data'")
+		then(response).containsText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "'")
 			.and(response).containsText("define('appns/Class1'");
 	}
 	

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/ApplicationDepsCommandTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/ApplicationDepsCommandTest.java
@@ -13,6 +13,7 @@ import org.bladerunnerjs.api.model.exception.command.NodeDoesNotExistException;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.model.SdkJsLib;
 import org.bladerunnerjs.plugin.commands.standard.ApplicationDepsCommand;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.spec.aliasing.AliasDefinitionsFileBuilder;
 import org.bladerunnerjs.spec.aliasing.AliasesFileBuilder;
 import org.junit.Before;
@@ -270,7 +271,7 @@ public class ApplicationDepsCommandTest extends SpecTest {
 				"    +--- '../../libs/javascript/br/src/br/UnknownClass.js'",
 			    "    +--- 'alias!appns.bs.b1.alias-ref' (alias dep.)",
 			    "    |    \\--- 'default-aspect/src/appns/Interface.js' (static dep.)",
-				"    |    \\--- 'alias!$data' (static dep.)",
+				"    |    \\--- '" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "' (static dep.)",
 				"    +--- 'default-aspect/index.html' (seed file)");
 	}
 	

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/DepInsightCommandTest.java
@@ -13,6 +13,7 @@ import org.bladerunnerjs.api.model.exception.command.CommandArgumentsException;
 import org.bladerunnerjs.api.model.exception.command.NodeDoesNotExistException;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.plugin.commands.standard.DepInsightCommand;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.spec.aliasing.AliasDefinitionsFileBuilder;
 import org.bladerunnerjs.spec.aliasing.AliasesFileBuilder;
 import org.junit.Before;
@@ -272,7 +273,7 @@ public class DepInsightCommandTest extends SpecTest {
 			"    |    \\--- 'alias!alias-ref' (alias dep.)",
 			"    |    |    \\--- 'default-aspect/index.html' (seed file)",
 			"    +--- 'default-aspect/src/appns/Class.js'",
-			"    +--- 'alias!$data' (alias dep.)");
+			"    +--- '" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "' (alias dep.)");
 	}
 	
 	@Test
@@ -287,7 +288,7 @@ public class DepInsightCommandTest extends SpecTest {
 			    "    |    \\--- 'alias!alias-ref' (alias dep.)",
 			    "    |    |    \\--- 'default-aspect/index.html' (seed file)",
 				"    +--- 'default-aspect/src/appns/Class.js'",
-				"    +--- 'alias!$data' (alias dep.)");
+				"    +--- '" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "' (alias dep.)");
 	}
 	
 	@Test
@@ -302,7 +303,7 @@ public class DepInsightCommandTest extends SpecTest {
 			    "    |    \\--- 'alias!alias ref' (alias dep.)",
 				"    |    |    \\--- 'default-aspect/index.html' (seed file)",
 				"    +--- 'default-aspect/src/appns/Class.js'",
-				"    +--- 'alias!$data' (alias dep.)");
+				"    +--- '" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "' (alias dep.)");
 	}
 	
 	@Ignore

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/WorkbenchDepsCommandTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/command/WorkbenchDepsCommandTest.java
@@ -14,6 +14,7 @@ import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.api.BladeWorkbench;
 import org.bladerunnerjs.plugin.bundlers.aliasing.AliasDefinitionsFile;
 import org.bladerunnerjs.plugin.commands.standard.WorkbenchDepsCommand;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.spec.aliasing.AliasDefinitionsFileBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -191,7 +192,7 @@ public class WorkbenchDepsCommandTest extends SpecTest {
 				"    +--- 'alias!br.alias' (alias dep.)",
 				"    |    \\--- '../../libs/javascript/ServicesLib/src/br/AliasRegistry.js' (static dep.)",
 				"    |    \\--- '../../libs/javascript/br/src/br/Class2.js' (static dep.)",
-				"    |    \\--- 'alias!$data' (static dep.)",
+				"    |    \\--- '" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "' (static dep.)",
 				"    +--- 'bladeset-bladeset/blades/blade/src/appns/bladeset/blade/Class1.js'",
 				"    +--- 'bladeset-bladeset/blades/blade/workbench/index.html' (seed file)");
 

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/commonjs/CommonJsSourceModuleTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/commonjs/CommonJsSourceModuleTest.java
@@ -3,6 +3,7 @@ package org.bladerunnerjs.spec.plugin.bundler.commonjs;
 import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.Aspect;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +46,7 @@ public class CommonJsSourceModuleTest extends SpecTest {
 		given(aspect).hasCommonJsPackageStyle();
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
 		then(response).doesNotContainText("define('br/AliasRegistry', function(require, exports, module) {\n");
-		then(response).doesNotContainText("define('alias!$data', function(require, exports, module) {\n");
-		then(response).doesNotContainText("define('alias!$data', function(require, exports, module) {\n");
+		then(response).doesNotContainText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "', function(require, exports, module) {\n");
+		then(response).doesNotContainText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "', function(require, exports, module) {\n");
 	}
 }

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/namespacedjs/NamespacedJsSourceModuleTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/namespacedjs/NamespacedJsSourceModuleTest.java
@@ -6,6 +6,7 @@ import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.Aspect;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
 import org.bladerunnerjs.model.SdkJsLib;
+import org.bladerunnerjs.plugin.plugins.require.AliasDataSourceModule;
 import org.bladerunnerjs.spec.aliasing.AliasesFileBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,7 +88,7 @@ public class NamespacedJsSourceModuleTest extends SpecTest {
 		given(aspect).hasNamespacedJsPackageStyle();
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
 		then(response).doesNotContainText("define('br/AliasRegistry', function(require, exports, module) {\n");
-		then(response).doesNotContainText("define('alias!$data', function(require, exports, module) {\n");
-		then(response).doesNotContainText("define('alias!$data', function(require, exports, module) {\n");
+		then(response).doesNotContainText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "', function(require, exports, module) {\n");
+		then(response).doesNotContainText("define('" + AliasDataSourceModule.PRIMARY_REQUIRE_PATH + "', function(require, exports, module) {\n");
 	}
 }


### PR DESCRIPTION
Purely a style change to clarify the purpose of the module ID used in webpack aliases.

https://github.com/briandipalma/brjs-app-converter/blob/master/templates/webpack.config.js#L56

<!---
@huboard:{"order":1660.0,"milestone_order":1660,"custom_state":""}
-->
