### PR TITLE
exclude wrapper folder in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@
 import static groovy.io.FileVisitResult.*  
 import static groovy.io.FileType.*
 
-def skipDirs = ~/^(build|\..*|src|out|bin)/  
+def skipDirs = ~/^(build|\..*|src|out|bin|wrapper)/
 def preDir = {  
 	if (skipDirs.matcher(it.name).matches())  
 		return SKIP_SUBTREE  


### PR DESCRIPTION
prevents gradle build from failing if there is a wrapper folder