### PR TITLE
Enable node style requires for index js files

### DIFF
--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingNodeDefaultRequires.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingNodeDefaultRequires.java
@@ -1,0 +1,130 @@
+package org.bladerunnerjs.spec.bundling.aspect;
+
+import org.bladerunnerjs.api.App;
+import org.bladerunnerjs.api.Aspect;
+import org.bladerunnerjs.api.JsLib;
+import org.bladerunnerjs.api.spec.engine.SpecTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AspectBundlingNodeDefaultRequires extends SpecTest {
+	private App app;
+	private Aspect aspect;
+	private JsLib sdkNamespaceLib, sdkCommonJsLib;
+	private StringBuffer response = new StringBuffer();
+
+	@Before
+	public void initTestObjects() throws Exception
+	{
+		given(brjs).automaticallyFindsBundlerPlugins()
+			.and(brjs).automaticallyFindsMinifierPlugins()
+			.and(brjs).hasBeenCreated();
+
+		app = brjs.app("app1");
+		aspect = app.aspect("default");
+
+		sdkNamespaceLib = brjs.sdkLib("sdkNamespaceLib");
+		sdkCommonJsLib = brjs.sdkLib("sdkCommonJsLib");
+
+		given(sdkNamespaceLib).hasNamespacedJsPackageStyle()
+			.and(sdkCommonJsLib).hasCommonJsPackageStyle();
+	}
+
+	// index.js references: common-js
+	@Test
+	public void anIndexJsFileContainedAspectSrcRootIsBundledWhenRequiredWithoutTheAssetNameCommonJsSimple() throws Exception {
+		given(aspect).hasClass("index")
+			.and(aspect).indexPageRequires("appns");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsDefinedClasses("appns");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryRootIsBundledWhenRequiredWithoutTheAssetNameCommonJsSimple() throws Exception {
+		given(sdkCommonJsLib).containsFileWithContents("br-lib.conf", "requirePrefix: root/pkg")
+			.and(sdkCommonJsLib).hasClass("root/pkg/index")
+			.and(aspect).indexPageRequires("root/pkg");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsDefinedClasses("root/pkg");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameCommonJsSimple() throws Exception {
+		given(sdkCommonJsLib).hasClass("pkg1/index")
+			.and(aspect).indexPageRequires("sdkCommonJsLib/pkg1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsCommonJsClasses("sdkCommonJsLib/pkg1/index");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameCommonJs() throws Exception {
+		given(sdkCommonJsLib).hasClass("pkg1/pkg2/Class1")
+			.and(sdkCommonJsLib).hasClass("pkg1/index")
+			.and(aspect).indexPageRequires("sdkCommonJsLib/pkg1", "sdkCommonJsLib/pkg1/pkg2/Class1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsCommonJsClasses("sdkCommonJsLib/pkg1/index");
+	}
+
+	// index.js references: namespaced-js
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameNamepacedJsSimple() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(sdkNamespaceLib).hasClass("sdkNamespaceLib.pkg1.index")
+			.and(aspect).indexPageRefersTo("sdkNamespaceLib.pkg1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsNamespacedJsClasses("sdkNamespaceLib.pkg1.index");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameNamepacedJs() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(sdkNamespaceLib).hasClass("sdkNamespaceLib.pkg1.pkg2.Class1")
+			.and(sdkNamespaceLib).hasClass("sdkNamespaceLib.pkg1.index")
+			.and(aspect).indexPageRefersTo("sdkNamespaceLib.pkg1", "sdkNamespaceLib.pkg1.pkg2.Class1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsNamespacedJsClasses("sdkNamespaceLib.pkg1.index");
+	}
+
+	// index.js references: mixed common-js lib, namespaced-js aspect
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameNamepacedJsAspectCommonJsLib() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(sdkCommonJsLib).hasClass("pkg1/pkg2/Class1")
+			.and(sdkCommonJsLib).hasClass("pkg1/index")
+			.and(aspect).indexPageRefersTo("sdkCommonJsLib.pkg1", "sdkCommonJsLib.pkg1.pkg2.Class1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsDefinedClasses("sdkCommonJsLib/pkg1");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenReferredToWithoutTheAssetNameNamepacedJsAspectCommonJsLibNoNamespaceEnforcement_HACK() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(sdkCommonJsLib).containsFile("no-namespace-enforcement")
+			.and(sdkCommonJsLib).hasClass("libRootName/pkg1/pkg2/Class1")
+			.and(sdkCommonJsLib).hasClass("libRootName/pkg1/index")
+			.and(aspect).indexPageRefersTo("libRootName.pkg1", "libRootName.pkg1.pkg2.Class1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsDefinedClasses("libRootName/pkg1");
+	}
+
+	@Test
+	public void anIndexJsFileContainedInAnSdkLibraryIsBundledWhenRequiredWithoutTheAssetNameNamepacedJsAspectCommonJsLibNoNamespaceEnforcement_HACK() throws Exception {
+		given(aspect).hasNamespacedJsPackageStyle()
+			.and(sdkCommonJsLib).containsFile("no-namespace-enforcement")
+			.and(sdkCommonJsLib).hasClass("libRootName/pkg1/pkg2/Class1")
+			.and(sdkCommonJsLib).hasClass("libRootName/pkg1/index")
+			.and(aspect).indexPageRequires("libRootName/pkg1", "libRootName/pkg1/pkg2/Class1");
+
+		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
+		then(response).containsDefinedClasses("libRootName/pkg1", "libRootName/pkg1/pkg2/Class1");
+	}
+
+}

--- a/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingOfMixedSources.java
+++ b/brjs-core-tests/src/test/java/org/bladerunnerjs/spec/bundling/aspect/AspectBundlingOfMixedSources.java
@@ -18,14 +18,14 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 	private Bladeset bladeset;
 	private Blade blade;
 
-	
+
 	@Before
 	public void initTestObjects() throws Exception
 	{
 		given(brjs).automaticallyFindsBundlerPlugins()
 			.and(brjs).automaticallyFindsMinifierPlugins()
 			.and(brjs).hasBeenCreated();
-		
+
 		app = brjs.app("app1");
 		aspect = app.aspect("default");
 		bladeset = app.bladeset("bladeset");
@@ -34,7 +34,7 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 		otherAspect = app.aspect("other");
 		userLib = app.jsLib("userLib");
 		otherUserLib = app.jsLib("otherUserLib");
-		
+
 		sdkNamespaceLib = brjs.sdkLib("sdkNamespaceLib");
 		otherSdkNamespaceLib = brjs.sdkLib("otherSdkNamespaceLib");
 		sdkCommonJsLib = brjs.sdkLib("sdkCommonJsLib");
@@ -45,31 +45,31 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 			.and(otherSdkNamespaceLib).hasNamespacedJsPackageStyle()
 			.and(sdkCommonJsLib).hasCommonJsPackageStyle()
 			.and(userLib).hasCommonJsPackageStyle()
-			.and(otherUserLib).hasCommonJsPackageStyle();			
+			.and(otherUserLib).hasCommonJsPackageStyle();
 	}
-	
+
 	// Namespace and CommonJs styles together
 	@Test
 	public void testThatNamespaceStyleLibraryCanProxyToCommonJsClassAndGetBundledInAspectIndexPage() throws Exception
 	{
-		given(sdkCommonJsLib).classFileHasContent("sdkCommonJsLib.Class1", "function empty() {};")
+		given(sdkCommonJsLib).classFileHasContent("sdkCommonJsLib/Class1", "function empty() {};")
 			.and(sdkNamespaceLib).classFileHasContent("sdkNamespaceLib.ProxyClass", "sdkNamespaceLib.ProxyClass = sdkCommonJsLib.Class1;")
 			.and(aspect).indexPageHasContent("require('sdkNamespaceLib/ProxyClass')");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
 		then(response).containsOrderedTextFragmentsAnyNumberOfTimes(
-				
+
 				// The sdkCommonJsLib is defined
 				"define('sdkCommonJsLib/Class1', function(require, exports, module) {",
 				"function empty() {};",
 				"});",
 				// The classes are both made available globally
 				"mergePackageBlock(window, {\"sdkNamespaceLib\":{},\"sdkCommonJsLib\":{}});",
-				// The namespaced style sdk class is assigned to the require of the CommonJsLib class  
+				// The namespaced style sdk class is assigned to the require of the CommonJsLib class
 				"requireAll(require, ['sdkCommonJsLib/Class1']);",
 				"sdkNamespaceLib.ProxyClass = sdkCommonJsLib.Class1;",
 				"sdkCommonJsLib.Class1 = require('sdkCommonJsLib/Class1');");
 	}
-	
+
 	@Test
 	public void testThatNamespaceStyleLibraryCanProxyToAnotherNamespaceLibraryClassAndGetBundledInAspectIndexPage() throws Exception
 	{
@@ -86,8 +86,8 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 				// The library class doing the proxying should be added next
 				"sdkNamespaceLib.ProxyClass = otherSdkNamespaceLib.Class1;");
 	}
-	
-	
+
+
 	// dependencies across multiple aspects
 	@Test
 	public void canBundleDependenciesForAnotherAspectCorrectlyWithCommonJsLibsAndSdkNamespaceLib() throws Exception {
@@ -102,7 +102,7 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 		then(response).containsCommonJsClasses("otherUserLib.Class1")
 			.and(response).doesNotContainText("userLib");
 	}
-	
+
 	// user libraries depending on other libraries
 	@Test
 	public void userLibraryCanDependOnSdkThirdpartyLibrary() throws Exception {
@@ -113,16 +113,16 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
 		then(response).containsDefinedClasses("jquery", "userLib/Class1");
 	}
-	
+
 	@Test
 	public void userLibraryCanDependOnSdkCommonJsLib() throws Exception {
-		given(sdkCommonJsLib).classFileHasContent("sdkCommonJsLib.Class1", "function empty() {};")
+		given(sdkCommonJsLib).classFileHasContent("sdkCommonJsLib/Class1", "function empty() {};")
 			.and(userLib).classFileHasContent("userLib.Class1", "require('sdkCommonJsLib/Class1');")
 			.and(aspect).indexPageHasContent("require('userLib/Class1');");
 		when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
 		then(response).containsDefinedClasses("sdkCommonJsLib/Class1", "userLib/Class1");
 	}
-	
+
 	// User thirdparty lib in 'libs' dir overriding an sdk thirdparty library
 	@Test
 	public void userThirdpartyLibraryIsLoadedInsteadOfSdkThirdpartyLibrary() throws Exception {
@@ -135,7 +135,7 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 		then(response).containsText("USER jquery-content")
 			.and(response).doesNotContainText("SDK jquery-content");
 	}
-	
+
 	@Test
 	public void srcDirectoryFullPackageStructureIsOptionalForEveryNodeType() throws Exception {
 		given(sdkNamespaceLib).hasNamespacedJsPackageStyle()
@@ -160,7 +160,7 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 		then(response).containsNamespacedJsClasses("NamespacedLibClass", "OtherUserLibNamespacedClass")
 			.and(response).containsCommonJsClasses("CommonJSLibClass", "UserLibCommonJSClass", "AspectClass", "BladesetClass", "BladeClass");
 	}
-	
+
 	@Test
 	public void exceptionIsThrownIfClassIsInIncorrectLocationAndSrcPathStartsWithAppRequirePrefix() throws Exception {
 		given(aspect).classRequires("App", "appns/mypackage/Class")
@@ -168,14 +168,14 @@ public class AspectBundlingOfMixedSources extends SpecTest {
 			.and(bladeset).hasBeenCreated()
 			.and(blade).hasClass("appns/mypkg/Class");
     	when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
-    	then(exceptions).verifyException(InvalidRequirePathException.class, 
+    	then(exceptions).verifyException(InvalidRequirePathException.class,
     			"apps/app1/bladeset-bladeset/blades/blade/src",
     			"appns",
     			"appns/bladeset/blade",
     			"apps/app1/bladeset-bladeset/blades/blade/src/appns/bladeset/blade",
     			"apps/app1/bladeset-bladeset/blades/blade/src");
 	}
-	
+
 	@Test
 	public void impliedRequirePrefixIsNotUsedIfNoNamespaceEnforcement_HACK_FlagIsUsedInALibrary() throws Exception {
 		given( brjs.sdkLib("myLib") ).containsFile("no-namespace-enforcement")
@@ -184,5 +184,5 @@ public class AspectBundlingOfMixedSources extends SpecTest {
     	when(aspect).requestReceivedInDev("js/dev/combined/bundle.js", response);
     	then(response).containsCommonJsClasses("pkg1/pkg2/pkg3/SomeClass");
 	}
-	
+
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/api/utility/RequirePathUtility.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/api/utility/RequirePathUtility.java
@@ -21,44 +21,48 @@ public class RequirePathUtility
 {
 
 	private static final Pattern matcherPattern = Pattern.compile("(require|br\\.Core\\.alias|caplin\\.alias|getAlias|getService)\\([ ]*[\"']([^)]+)[\"'][ ]*\\)");
-	
-	public static void assertIdentifierCorrectlyNamespaced(Asset asset, String identifier) throws NamespaceException 
-	{	
+
+	public static void assertIdentifierCorrectlyNamespaced(Asset asset, String identifier) throws NamespaceException
+	{
 		AssetContainer assetContainer = asset.assetContainer();
 		if (asset.file().isChildOf(assetContainer.file("resources"))) {
 			assertIdentifierCorrectlyNamespaced(assetContainer, identifier);
 			return;
 		}
-		
+
 		String assetParentRequirePath = StringUtils.substringBeforeLast(calculateRequireSuffix(asset), "/");
 		Asset parentAsset;
 		while (assetParentRequirePath.length() > 0) {
-			parentAsset = assetContainer.asset(assetParentRequirePath);
-			if (parentAsset instanceof DirectoryLinkedAsset) {
-				String namespace = calculateNamespace(assetParentRequirePath)+".";
-				assertIdentifierCorrectlyNamespaced(assetContainer, namespace, identifier);
-				return;
+			String[] suffixes = { "@dir", "@root" };
+			for (String suffix: suffixes) {
+				parentAsset = assetContainer.asset(assetParentRequirePath + suffix);
+				if (parentAsset instanceof DirectoryLinkedAsset) {
+					String namespace = calculateNamespace(assetParentRequirePath)+".";
+					assertIdentifierCorrectlyNamespaced(assetContainer, namespace, identifier);
+					return;
+				}
 			}
+
 			assetParentRequirePath = StringUtils.substringBeforeLast(assetParentRequirePath, "/");
-		}	
+		}
 	}
-	
-	public static void assertIdentifierCorrectlyNamespaced(AssetContainer assetContainer, String identifier) throws NamespaceException 
-	{	
+
+	public static void assertIdentifierCorrectlyNamespaced(AssetContainer assetContainer, String identifier) throws NamespaceException
+	{
 		String namespace = calculateNamespace(assetContainer.requirePrefix())+".";
 		assertIdentifierCorrectlyNamespaced(assetContainer, namespace, identifier);
 	}
-	
+
 	private static void assertIdentifierCorrectlyNamespaced(AssetContainer assetContainer, String namespace, String identifier) throws NamespaceException {
 		if (assetContainer.isNamespaceEnforced() && !identifier.startsWith(namespace)) {
 			throw new NamespaceException( "The identifier '" + identifier + "' is not correctly namespaced.\nNamespace '" + namespace + "*' was expected.");
 		}
 	}
-	
+
 	public static String calculateRequireSuffix(Asset asset) {
 		return calculateRequireSuffix(asset.getPrimaryRequirePath());
 	}
-	
+
 	public static String calculateRequireSuffix(String requirePath)
 	{
 		String requirePathSuffix = requirePath;
@@ -69,29 +73,29 @@ public class RequirePathUtility
 		}
 		return requirePathSuffix;
 	}
-	
+
 	public static String calculateNamespace(AssetContainer assetContainer) {
 		return calculateNamespace(assetContainer.requirePrefix());
 	}
-	
+
 	public static String calculateNamespace(Asset asset) {
 		return calculateNamespace(asset.getPrimaryRequirePath());
 	}
-	
-	public static String calculateNamespace(String requirePath) 
+
+	public static String calculateNamespace(String requirePath)
 	{
 		return calculateRequireSuffix(requirePath).replace("/", ".");
 	}
-	
-	
+
+
 	public static void addRequirePathsFromReader(Reader reader, Set<String> dependencies, List<String> aliases) throws IOException {
 		StringWriter stringWriter = new StringWriter();
 		IOUtils.copy(reader, stringWriter);
-		
+
 		Matcher m = matcherPattern.matcher(stringWriter.toString());
 		while (m.find()) {
 			String methodArgument = m.group(2);
-			
+
 			if (m.group(1).startsWith("require")) {
 				String requirePath = methodArgument;
 				dependencies.add(requirePath);
@@ -106,5 +110,5 @@ public class RequirePathUtility
 			}
 		}
 	}
-	
+
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractBundlableNode.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/AbstractBundlableNode.java
@@ -37,28 +37,28 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 
 	private final MemoizedValue<BundleSet> bundleSet;
 	private RequirePlugin defaultRequirePlugin;
-	
+
 	// TODO: these messages need to be covered off in a spec test (a single test would be perfect)
 	public class Messages {
 		public static final String REQUEST_HANDLED_MSG = "Handling logical request '%s' for app '%s'.";
 		public static final String CONTEXT_IDENTIFIED_MSG = "%s '%s' identified as context for request '%s'.";
 		public static final String BUNDLER_IDENTIFIED_MSG = "Bundler '%s' identified as handler for request '%s'.";
 	}
-	
+
 	public AbstractBundlableNode(RootNode rootNode, Node parent, MemoizedFile dir) {
 		super(rootNode, parent, dir);
 		defaultRequirePlugin = root().plugins().requirePlugin("default");
 		bundleSet = new MemoizedValue<>(this.getClass().getSimpleName()+" bundleSet", root(), root().dir(), app().dir());
 	}
-	
+
 	@Override
 	public List<LinkedAsset> seedAssets() {
 		List<LinkedAsset> seedAssets = new ArrayList<>();
 		seedAssets.addAll( assetDiscoveryResult().getRegisteredSeedAssets() );
 		for (AssetContainer scopeAssetContainer : scopeAssetContainers()) {
-			if (scopeAssetContainer instanceof Aspect || scopeAssetContainer instanceof Bladeset 
+			if (scopeAssetContainer instanceof Aspect || scopeAssetContainer instanceof Bladeset
 						|| scopeAssetContainer instanceof Blade || scopeAssetContainer instanceof Workbench<?>) {
-				Asset assetContainerRootAsset = scopeAssetContainer.asset(scopeAssetContainer.requirePrefix());
+				Asset assetContainerRootAsset = scopeAssetContainer.asset(scopeAssetContainer.requirePrefix() + "@root");
 				if (assetContainerRootAsset instanceof LinkedAsset) {
 					seedAssets.add( (LinkedAsset) assetContainerRootAsset );
 				}
@@ -66,7 +66,7 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 		}
 		return seedAssets;
 	}
-		
+
 	@Override
 	public LinkedAsset getLinkedAsset(String requirePath) throws RequirePathException {
 		LinkedAsset linkedAsset;
@@ -74,7 +74,7 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 		RequirePlugin requirePlugin;
 		String pluginName;
 		String requirePathSuffix;
-		
+
 		if(requirePath.contains("!")) {
 			pluginName = StringUtils.substringBefore(requirePath, "!");
 			requirePathSuffix = StringUtils.substringAfter(requirePath, "!");
@@ -84,7 +84,7 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 			pluginName = "default";
 			requirePathSuffix = requirePath;
 		}
-		
+
 		if (requirePlugin == null) {
 			linkedAsset = (LinkedAsset) defaultRequirePlugin.getAsset(this, requirePath);
 			noLinkedAssetException = new RuntimeException("Unable to find a require plugin for the prefix '"+pluginName+"' and there is no asset registered for the require path '"+requirePath+"'.");
@@ -92,21 +92,21 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 			linkedAsset = (LinkedAsset) requirePlugin.getAsset(this, requirePathSuffix);
 			noLinkedAssetException = new RuntimeException("There is no asset registered for the require path '"+requirePathSuffix+"'.");
 		}
-		
+
 		if (linkedAsset == null) {
 			throw noLinkedAssetException;
 		}
-		
+
 		return linkedAsset;
 	}
-	
-	@Override 
+
+	@Override
 	public BundleSet getBundleSet() throws ModelOperationException {
 		return bundleSet.value(() -> {
 			return BundleSetCreator.createBundleSet(this);
 		});
 	}
-	
+
 	@Override
 	public ResponseContent handleLogicalRequest(String logicalRequestPath, UrlContentAccessor contentAccessor, String version) throws MalformedRequestException, ResourceNotFoundException, ContentProcessingException {
 		try {
@@ -116,26 +116,26 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 			throw new ContentProcessingException(e);
 		}
 	}
-	
+
 	@Override
 	public ResponseContent handleLogicalRequest(String logicalRequestpath, BundleSet bundleSet, UrlContentAccessor contentAccessor, String version) throws MalformedRequestException, ResourceNotFoundException, ContentProcessingException {
 		BundlableNode bundlableNode = bundleSet.bundlableNode();
 		App app = bundlableNode.app();
 		Logger logger = app.root().logger(AbstractBundlableNode.class);
-		
+
 		logger.debug(Messages.REQUEST_HANDLED_MSG, logicalRequestpath, app.getName());
-		
+
 		String name = (bundlableNode instanceof NamedNode) ? ((NamedNode) bundlableNode).getName() : "default";
 		logger.debug(Messages.CONTEXT_IDENTIFIED_MSG, bundlableNode.getTypeName(), name, logicalRequestpath);
-		
+
 		ContentPlugin contentProvider = app.root().plugins().contentPluginForLogicalPath(logicalRequestpath);
-		
+
 		if(contentProvider == null) {
 			throw new ResourceNotFoundException("No content provider could be found found the logical request path '" + logicalRequestpath + "'");
 		}
-		
+
 		logger.debug(Messages.BUNDLER_IDENTIFIED_MSG, contentProvider.getPluginClass().getSimpleName(), logicalRequestpath);
-		
+
 		ResponseContent pluginResponseContent = contentProvider.handleRequest(logicalRequestpath, bundleSet, contentAccessor, version);
 		try {
 			MissingTokenHandler missingTokenHandler = (bundleSet.bundlableNode() instanceof TestPack) ? new ExceptionThrowingMissingTokenHandler() : null;
@@ -144,17 +144,17 @@ public abstract class AbstractBundlableNode extends AbstractAssetContainer imple
 			throw new RuntimeException(ex);
 		}
 	}
-	
+
 	@Override
 	public List<Asset> assets(Asset asset, List<String> requirePaths) throws RequirePathException {
 		List<Asset> assets = new ArrayList<Asset>();
-		
-		for(String requirePath : requirePaths) {				
+
+		for(String requirePath : requirePaths) {
 			String canonicalRequirePath = asset.assetContainer().canonicaliseRequirePath(asset, requirePath);
 			assets.add(getLinkedAsset(canonicalRequirePath));
 		}
-		
+
 		return assets;
 	}
-	
+
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/DirectoryAsset.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/DirectoryAsset.java
@@ -27,15 +27,15 @@ public class DirectoryAsset implements DirectoryLinkedAsset
 		this.assetContainer = assetContainer;
 		this.dir = dir;
 		this.implicitDependencies.addAll(implicitDependencies);
-		
+
 		primaryRequirePath = getRequirePath(requirePrefix, dir);
 	}
-	
+
 	@Override
 	public void addImplicitDependencies(List<Asset> implicitDependencies) {
 		this.implicitDependencies.addAll(implicitDependencies);
 	}
-	
+
 	@Override
 	public Reader getReader() throws IOException
 	{
@@ -85,12 +85,12 @@ public class DirectoryAsset implements DirectoryLinkedAsset
 	{
 		return assetContainer;
 	}
-	
+
 	@Override
 	public boolean isScopeEnforced() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isRequirable()
 	{
@@ -98,10 +98,11 @@ public class DirectoryAsset implements DirectoryLinkedAsset
 	}
 
 	public static String getRequirePath(String requirePrefix, MemoizedFile dir) {
-		if (requirePrefix == "") {
-			return dir.getName();
+		if (requirePrefix.equals("")) {
+			return dir.getName() + "@dir";
 		}
-		return requirePrefix+"/"+dir.getName();
+
+		return requirePrefix + "/" + dir.getName() + "@dir";
 	}
-	
+
 }

--- a/brjs-core/src/main/java/org/bladerunnerjs/model/IndexPageAsset.java
+++ b/brjs-core/src/main/java/org/bladerunnerjs/model/IndexPageAsset.java
@@ -39,7 +39,7 @@ public class IndexPageAsset extends LinkedFileAsset {
 			throw new ModelOperationException(e);
 		}
 		
-		Asset rootAsset = assetContainer().asset(assetContainer().requirePrefix());
+		Asset rootAsset = assetContainer().asset(assetContainer().requirePrefix() + "@root");
 		if (rootAsset != null) {
 			assetList.add(rootAsset);			
 		}

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/brjsconformant/BRJSConformantAssetPlugin.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/brjsconformant/BRJSConformantAssetPlugin.java
@@ -26,30 +26,30 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 {
 
 	public static final String IMPLICIT_PACKAGE_USED = "The location '%s' contains a directory with the same name as the parent asset container require prefix ('%s'), using '%s' as the implied require prefix for this location.";
-	
+
 	@Override
 	public void discoverAssets(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, List<Asset> implicitDependencies, AssetRegistry assetDiscoveryInitiator)
 	{
 		// only create assets if we're at the root of the asset container *and* its not a default bladeset
-		if (assetContainer instanceof DefaultBladeset || !neccessaryChildDirsArePresent(assetContainer) 
+		if (assetContainer instanceof DefaultBladeset || !neccessaryChildDirsArePresent(assetContainer)
 				|| assetContainer.dir() != dir || assetDiscoveryInitiator.hasRegisteredAsset(BRJSConformantRootDirectoryLinkedAsset.calculateRequirePath(assetContainer))) {
 			return;
 		}
-		
+
 		List<Asset> assets = new ArrayList<>();
-		 
-		LinkedAsset rootAsset = new BRJSConformantRootDirectoryLinkedAsset(assetContainer); 
+
+		LinkedAsset rootAsset = new BRJSConformantRootDirectoryLinkedAsset(assetContainer);
 		assetDiscoveryInitiator.registerAsset(rootAsset);
 		assets.add(rootAsset);
-		
+
 		for (MemoizedFile srcDir : getSrcDirs(assetContainer)) {
 			if (useImpliedRequirePrefix(assetContainer)) {
-				discoverFurtherAssetsForChild(assetContainer, srcDir, requirePrefix, implicitDependencies, assetDiscoveryInitiator, rootAsset);								
+				discoverFurtherAssetsForChild(assetContainer, srcDir, requirePrefix, implicitDependencies, assetDiscoveryInitiator, rootAsset);
 			} else {
-				discoverFurtherAssetsForChild(assetContainer, srcDir, "", implicitDependencies, assetDiscoveryInitiator, rootAsset);				
+				discoverFurtherAssetsForChild(assetContainer, srcDir, "", implicitDependencies, assetDiscoveryInitiator, rootAsset);
 			}
 		}
-		
+
 		List<Asset> implicitResourcesDependencies = new ArrayList<>();
 		implicitResourcesDependencies.addAll(implicitDependencies);
 		implicitResourcesDependencies.add(rootAsset);
@@ -57,25 +57,25 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 			List<Asset> discoveredAssets = createAssetsForChildDir(assetContainer, resourceDir, requirePrefix, implicitResourcesDependencies, assetDiscoveryInitiator, rootAsset);
 			rootAsset.addImplicitDependencies(discoveredAssets);
 		}
-		
+
 		for (MemoizedFile testDir : getTestDirs(assetContainer)) {
 			discoverFurtherAssetsForChild(assetContainer, testDir, "test/"+requirePrefix, implicitDependencies, assetDiscoveryInitiator, rootAsset);
 		}
-		
+
 		for (MemoizedFile themeDir : getThemeDirs(assetContainer)) {
 			String themeRequirePrefix = "theme!"+themeDir.getName()+":"+requirePrefix;
 			List<Asset> discoveredAssets = createAssetsForChildDir(assetContainer, themeDir, themeRequirePrefix, implicitDependencies, assetDiscoveryInitiator, rootAsset);
 			rootAsset.addImplicitDependencies(discoveredAssets);
 		}
 	}
-	
+
 	private boolean useImpliedRequirePrefix(AssetContainer assetContainer) {
-		if (assetContainer instanceof JsLib || assetContainer instanceof TestPack) { 
+		if (assetContainer instanceof JsLib || assetContainer instanceof TestPack) {
 			return assetContainer.isNamespaceEnforced();
 		}
 		return true;
 	}
-	
+
 	private String calculateImplicitOrExplicitRequirePrefixDirectory(AssetContainer assetContainer, String srcDirName) {
 		MemoizedFile brjsDir = assetContainer.root().dir();
 		String rootPath = srcDirName;
@@ -84,16 +84,16 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		if (!srcDir.isDirectory()) {
 			return srcDirName;
 		}
-		
+
 		String rootRequirePrefix = StringUtils.substringBefore(assetContainer.requirePrefix(), "/");
 		MemoizedFile rootRequirePrefixDir = srcDir.file(rootRequirePrefix);
-		
+
 		String nestedRequirePrefixPath = srcDirName+"/"+assetContainer.requirePrefix();
 		MemoizedFile nestedRequirePrefixDir = assetContainer.file(nestedRequirePrefixPath);
-		
+
 		MemoizedFile rootPathDir = assetContainer.file(rootPath);
 		boolean explicitRequirePrefixDirsExist = nestedRequirePrefixDir.isDirectory();
-		
+
 		if (rootRequirePrefixDir.exists() && !explicitRequirePrefixDirsExist) {
 			InvalidRequirePathException wrappedRequirePathException = new InvalidRequirePathException(
 					String.format("The location '%s' contains a directory with the same name as the root require prefix ('%s') which suggests it's require prefix is explicitly defined"
@@ -108,7 +108,7 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 			throw new RuntimeException(wrappedRequirePathException);
 
 		}
-		
+
 		BRJS brjs = assetContainer.root();
 		Logger logger = brjs.logger(this.getClass());
 		if (explicitRequirePrefixDirsExist && useImpliedRequirePrefix(assetContainer)) {
@@ -117,7 +117,7 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		logger.debug(IMPLICIT_PACKAGE_USED, assetContainer.root().dir().getRelativePath(srcDir), assetContainer.requirePrefix(), assetContainer.requirePrefix());
 		return rootPath;
 	}
-	
+
 	private List<MemoizedFile> getSrcDirs(AssetContainer assetContainer)
 	{
 		List<MemoizedFile> dirs = new ArrayList<>();
@@ -131,7 +131,7 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		}
 		return filterNonExistantDirs(dirs);
 	}
-	
+
 	private List<MemoizedFile> getThemeDirs(AssetContainer assetContainer)
 	{
 		if (assetContainer instanceof TestPack) {
@@ -143,13 +143,13 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		}
 		return filterNonExistantDirs(themeDirs);
 	}
-	
+
 	private List<MemoizedFile> getResourceDirs(AssetContainer assetContainer)
 	{
 		List<MemoizedFile> dirs = createFilesForFilePaths(assetContainer, Arrays.asList("resources") );
 		return filterNonExistantDirs(dirs);
 	}
-	
+
 	private List<MemoizedFile> getTestDirs(AssetContainer assetContainer)
 	{
 		if (assetContainer instanceof TestPack) {
@@ -169,24 +169,32 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		}
 		return existingDirs;
 	}
-	
-	
-	private List<Asset> createAssetsForChildDir(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, List<Asset> implicitDependencies, 
+
+
+	private List<Asset> createAssetsForChildDir(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, List<Asset> implicitDependencies,
 			AssetRegistry assetDiscoveryInitiator, Asset parentAsset)
 	{
 		List<Asset> assets = new ArrayList<>();
 		Asset child = getOrCreateAsset(assetContainer, dir, requirePrefix, assetDiscoveryInitiator, implicitDependencies, parentAsset);
 		assets.add(child);
-		assets.addAll( discoverFurtherAssetsForChild(assetContainer, dir, child.getPrimaryRequirePath(), implicitDependencies, assetDiscoveryInitiator, child) );
+		assets.addAll( discoverFurtherAssetsForChild(assetContainer, dir, sanitizeChildDirRequirePrefix(child.getPrimaryRequirePath()), implicitDependencies, assetDiscoveryInitiator, child) );
 		return assets;
 	}
-	
+
+	private String sanitizeChildDirRequirePrefix(String dirAssetRequirePath) {
+		if (dirAssetRequirePath.contains("@dir")) {
+			return dirAssetRequirePath.replaceFirst("@dir", "");
+		}
+
+		return dirAssetRequirePath;
+	}
+
 	private List<Asset> discoverFurtherAssetsForChild(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, List<Asset> implicitDependencies, AssetRegistry assetDiscoveryInitiator, Asset parent)
 	{
 		List<Asset> furtherAssetImplicitDependencies = new ArrayList<>();
 		furtherAssetImplicitDependencies.addAll(implicitDependencies);
 		furtherAssetImplicitDependencies.add(parent);
-		
+
 		List<Asset> discoveredAssets = assetDiscoveryInitiator.discoverFurtherAssets(dir, requirePrefix, furtherAssetImplicitDependencies);
 		List<Asset> dependentAssets = new ArrayList<>();
 		if (parent instanceof LinkedAsset) {
@@ -198,15 +206,17 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 			}
 			((LinkedAsset) parent).addImplicitDependencies(dependentAssets);
 		}
-		
+
 		for (MemoizedFile childDir : dir.dirs()) {
 			discoveredAssets.addAll( createAssetsForChildDir(assetContainer, childDir, requirePrefix, implicitDependencies, assetDiscoveryInitiator, parent) );
 		}
 		return discoveredAssets;
 	}
 
-	public Asset getOrCreateAsset(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, AssetRegistry assetDiscoveryInitiator, List<Asset> implicitDependencies, Asset parent) {
-		if (!assetDiscoveryInitiator.hasRegisteredAsset(DirectoryAsset.getRequirePath(requirePrefix, dir))) {
+	private Asset getOrCreateAsset(AssetContainer assetContainer, MemoizedFile dir, String requirePrefix, AssetRegistry assetDiscoveryInitiator, List<Asset> implicitDependencies, Asset parent) {
+		String requirePath = DirectoryAsset.getRequirePath(requirePrefix, dir);
+
+		if (!assetDiscoveryInitiator.hasRegisteredAsset(requirePath)) {
 			List<Asset> furtherAssetImplicitDependencies = new ArrayList<>();
 			furtherAssetImplicitDependencies.addAll(implicitDependencies);
 			furtherAssetImplicitDependencies.add(parent);
@@ -214,10 +224,10 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 			assetDiscoveryInitiator.registerAsset(asset);
 			return asset;
 		} else {
-			return assetDiscoveryInitiator.getRegisteredAsset( DirectoryAsset.getRequirePath(requirePrefix, dir) );
+			return assetDiscoveryInitiator.getRegisteredAsset( requirePath );
 		}
 	}
-	
+
 	private List<MemoizedFile> createFilesForFilePaths(AssetContainer assetContainer, List<String> filePaths) {
 		List<MemoizedFile> files = new ArrayList<>();
 		for (String filePath : filePaths) {
@@ -230,7 +240,7 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 		List<MemoizedFile> expectedDirs = getSrcDirs(assetContainer);
 		expectedDirs.addAll(getResourceDirs(assetContainer));
 		expectedDirs.addAll(getTestDirs(assetContainer));
-		expectedDirs.addAll(getThemeDirs((assetContainer)));
+		expectedDirs.addAll(getThemeDirs(assetContainer));
 		for (MemoizedFile dir : expectedDirs) {
 			if (dir.isDirectory()) {
 				return true;
@@ -243,5 +253,5 @@ public class BRJSConformantAssetPlugin extends AbstractAssetPlugin
 	public void setBRJS(BRJS brjs)
 	{
 	}
-	
+
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/brjsconformant/BRJSConformantRootDirectoryLinkedAsset.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/brjsconformant/BRJSConformantRootDirectoryLinkedAsset.java
@@ -8,12 +8,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.bladerunnerjs.api.Asset;
+import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.api.SourceModule;
 import org.bladerunnerjs.api.TestPack;
 import org.bladerunnerjs.api.memoization.MemoizedFile;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 import org.bladerunnerjs.model.AssetContainer;
-import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.model.DirectoryLinkedAsset;
 
 
@@ -27,10 +27,10 @@ public class BRJSConformantRootDirectoryLinkedAsset implements DirectoryLinkedAs
 
 	public BRJSConformantRootDirectoryLinkedAsset(AssetContainer assetContainer) {
 		this.assetContainer = assetContainer;
-		this.dir = assetContainer.dir();		
+		this.dir = assetContainer.dir();
 		primaryRequirePath = calculateRequirePath(assetContainer);
 	}
-	
+
 	@Override
 	public void addImplicitDependencies(List<Asset> implicitDependencies) {
 		for (Asset asset : implicitDependencies) {
@@ -40,7 +40,7 @@ public class BRJSConformantRootDirectoryLinkedAsset implements DirectoryLinkedAs
 			this.implicitDependencies.add(asset);
 		}
 	}
-	
+
 	@Override
 	public Reader getReader() throws IOException
 	{
@@ -88,22 +88,24 @@ public class BRJSConformantRootDirectoryLinkedAsset implements DirectoryLinkedAs
 	{
 		return assetContainer;
 	}
-	
+
 	@Override
 	public boolean isScopeEnforced() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isRequirable()
 	{
 		return false;
 	}
-	
+
 	public static String calculateRequirePath(AssetContainer assetContainer) {
+		String requirePrefix = assetContainer.requirePrefix() + "@root";
 		if (assetContainer instanceof TestPack) {
-			return "test/"+assetContainer.requirePrefix();			
+			return "test/" + requirePrefix;
 		}
-		return assetContainer.requirePrefix();
+
+		return requirePrefix;
 	}
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/commonjs/DefaultCommonJsSourceModule.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/commonjs/DefaultCommonJsSourceModule.java
@@ -219,7 +219,10 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 
 	public static String calculateRequirePath(String requirePrefix, MemoizedFile assetFile)
 	{
-		return requirePrefix+"/"+assetFile.requirePathName();
+		if (assetFile.getName().equals("index.js")) {
+			return requirePrefix;
+		}
+		return requirePrefix + "/" + assetFile.requirePathName();
 	}
 
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/commonjs/DefaultCommonJsSourceModule.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/commonjs/DefaultCommonJsSourceModule.java
@@ -8,8 +8,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.bladerunnerjs.api.Asset;
+import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.api.memoization.Getter;
 import org.bladerunnerjs.api.memoization.MemoizedFile;
 import org.bladerunnerjs.api.memoization.MemoizedValue;
@@ -20,7 +20,6 @@ import org.bladerunnerjs.api.model.exception.RequirePathException;
 import org.bladerunnerjs.api.model.exception.UnresolvableRequirePathException;
 import org.bladerunnerjs.api.utility.RequirePathUtility;
 import org.bladerunnerjs.model.AssetContainer;
-import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.model.SourceModulePatch;
 import org.bladerunnerjs.utility.UnicodeReader;
 
@@ -28,9 +27,9 @@ import com.Ostermiller.util.ConcatReader;
 
 public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 	private MemoizedFile assetFile;
-	
+
 	private SourceModulePatch patch;
-	
+
 	private MemoizedValue<ComputedValue> computedValue;
 	private List<String> requirePaths = new ArrayList<>();
 
@@ -44,39 +43,36 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 		this.assetFile = assetFile;
 		this.assetContainer = assetContainer;
 		this.implicitDependencies = implicitDependencies;
-		
+
 		primaryRequirePath = calculateRequirePath(requirePrefix, assetFile);
 		requirePaths.add(primaryRequirePath);
-		
+
 		patch = SourceModulePatch.getPatchForRequirePath(assetContainer, primaryRequirePath);
 		computedValue = new MemoizedValue<>(getAssetPath()+" - computedValue", assetContainer.root(), assetFile, patch.getPatchFile());
 	}
-	
+
 	@Override
 	public void addImplicitDependencies(List<Asset> implicitDependencies) {
 		this.implicitDependencies.addAll(implicitDependencies);
 	}
-	
+
 	@Override
 	public List<Asset> getDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		List<Asset> dependendAssets = new ArrayList<>();
-		
-		String parentRequirePath = StringUtils.substringBeforeLast(getPrimaryRequirePath(), "/");
-		assetContainer.asset(parentRequirePath);
-		
+
 		dependendAssets.addAll( getPreExportDefineTimeDependentAssets(bundlableNode) );
 		dependendAssets.addAll( getPostExportDefineTimeDependentAssets(bundlableNode) );
 		dependendAssets.addAll( getUseTimeDependentAssets(bundlableNode) );
 		dependendAssets.addAll(implicitDependencies);
-		
+
 		return dependendAssets;
 	}
-	
+
 	@Override
 	public List<String> getRequirePaths() {
 		return requirePaths;
 	}
-	
+
 	public Reader getUnalteredContentReader() throws IOException {
 		try
 		{
@@ -93,7 +89,7 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 			throw new RuntimeException(ex);
 		}
 	}
-	
+
 	@Override
 	public Reader getReader() throws IOException {
 		return new ConcatReader(new Reader[] {
@@ -102,71 +98,71 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 			new StringReader( COMMONJS_DEFINE_BLOCK_FOOTER )
 		});
 	}
-	
+
 	@Override
 	public String getPrimaryRequirePath() {
 		return primaryRequirePath;
 	}
-	
+
 	@Override
 	public boolean isEncapsulatedModule() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isGlobalisedModule() {
 		return false;
 	}
-	
+
 	@Override
 	public List<Asset> getPreExportDefineTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		return getSourceModulesForRequirePaths( bundlableNode, getComputedValue().preExportDefineTimeRequirePaths );
 	}
-	
+
 	@Override
 	public List<Asset> getPostExportDefineTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		return getSourceModulesForRequirePaths( bundlableNode, getComputedValue().postExportDefineTimeRequirePaths );
 	}
-	
+
 	@Override
 	public List<Asset> getUseTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		return getSourceModulesForRequirePaths( bundlableNode, getComputedValue().useTimeRequirePaths );
 	}
-	
+
 	@Override
 	public MemoizedFile file() {
 		return assetFile;
 	}
-	
+
 	@Override
 	public String getAssetName() {
 		return assetFile.getName();
 	}
-	
+
 	@Override
 	public String getAssetPath() {
 		return assetContainer.app().dir().getRelativePath(assetFile);
 	}
-	
+
 	private ComputedValue getComputedValue() throws ModelOperationException {
 		DefaultCommonJsSourceModule sourceModule = this;
 		return computedValue.value(new Getter<ModelOperationException>() {
 			@Override
 			public Object get() throws ModelOperationException {
 				ComputedValue computedValue = new ComputedValue();
-				
+
 				try {
-					try(Reader reader = new CommonJsPreExportDefineTimeDependenciesReader(sourceModule)) 
+					try(Reader reader = new CommonJsPreExportDefineTimeDependenciesReader(sourceModule))
 					{
 						RequirePathUtility.addRequirePathsFromReader(reader, computedValue.preExportDefineTimeRequirePaths, computedValue.aliases);
 					}
-					
-					try(Reader reader = new CommonJsPostExportDefineTimeDependenciesReader(sourceModule)) 
+
+					try(Reader reader = new CommonJsPostExportDefineTimeDependenciesReader(sourceModule))
 					{
 						RequirePathUtility.addRequirePathsFromReader(reader, computedValue.postExportDefineTimeRequirePaths, computedValue.aliases);
 					}
 
-					try(Reader reader = new CommonJsUseTimeDependenciesReader(sourceModule)) 
+					try(Reader reader = new CommonJsUseTimeDependenciesReader(sourceModule))
 					{
 						RequirePathUtility.addRequirePathsFromReader(reader, computedValue.useTimeRequirePaths, computedValue.aliases);
 					}
@@ -174,7 +170,7 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 				catch(IOException e) {
 					throw new ModelOperationException(e);
 				}
-				
+
 				return computedValue;
 			}
 		});
@@ -196,7 +192,7 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 			throw new ModelOperationException(e);
 		}
 	}
-	
+
 	private class ComputedValue {
 		public Set<String> preExportDefineTimeRequirePaths = new LinkedHashSet<>();
 		public Set<String> postExportDefineTimeRequirePaths = new LinkedHashSet<>();
@@ -209,21 +205,21 @@ public class DefaultCommonJsSourceModule implements CommonJsSourceModule {
 	{
 		return assetContainer;
 	}
-	
+
 	@Override
 	public boolean isScopeEnforced() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isRequirable()
 	{
 		return true;
 	}
-	
+
 	public static String calculateRequirePath(String requirePrefix, MemoizedFile assetFile)
 	{
 		return requirePrefix+"/"+assetFile.requirePathName();
 	}
-	
+
 }

--- a/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/namespacedjs/NamespacedJsSourceModule.java
+++ b/plugins/brjs-plugins/src/main/java/org/bladerunnerjs/plugin/bundlers/namespacedjs/NamespacedJsSourceModule.java
@@ -8,12 +8,12 @@ import java.util.Collections;
 import java.util.List;
 
 import org.bladerunnerjs.api.Asset;
+import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.api.SourceModule;
 import org.bladerunnerjs.api.memoization.MemoizedFile;
 import org.bladerunnerjs.api.model.exception.ModelOperationException;
 import org.bladerunnerjs.api.model.exception.RequirePathException;
 import org.bladerunnerjs.model.AssetContainer;
-import org.bladerunnerjs.api.BundlableNode;
 import org.bladerunnerjs.model.LinkedFileAsset;
 import org.bladerunnerjs.model.SourceModulePatch;
 import org.bladerunnerjs.model.TrieBasedDependenciesCalculator;
@@ -23,7 +23,7 @@ import com.Ostermiller.util.ConcatReader;
 import com.google.common.base.Joiner;
 
 public class NamespacedJsSourceModule implements SourceModule {
-	
+
 	private AssetContainer assetContainer;
 	private MemoizedFile assetFile;
 	private LinkedFileAsset linkedFileAsset;
@@ -35,20 +35,20 @@ public class NamespacedJsSourceModule implements SourceModule {
 	private TrieBasedDependenciesCalculator trieBasedPostExportDefineTimeDependenciesCalculator;
 	private List<Asset> implicitDependencies;
 	public static final String JS_STYLE = "namespaced-js";
-	
+
 	public NamespacedJsSourceModule(AssetContainer assetContainer, String requirePrefix, MemoizedFile jsFile, List<Asset> implicitDependencies)
 	{
 		this.assetContainer = assetContainer;
 		this.assetFile = jsFile;
 		this.linkedFileAsset =  new LinkedFileAsset(assetFile, assetContainer, requirePrefix, implicitDependencies);
 		this.implicitDependencies = implicitDependencies;
-		
+
 		primaryRequirePath = calculateRequirePath(requirePrefix, jsFile);
 		requirePaths.add(primaryRequirePath);
 
 		patch = SourceModulePatch.getPatchForRequirePath(assetContainer, primaryRequirePath);
 	}
-	
+
 	@Override
 	public void addImplicitDependencies(List<Asset> implicitDependencies) {
 		this.implicitDependencies.addAll(implicitDependencies);
@@ -63,7 +63,7 @@ public class NamespacedJsSourceModule implements SourceModule {
 		dependendAssets.addAll(implicitDependencies);
 		return dependendAssets;
 	}
-	
+
 	public Reader getUnalteredContentReader() throws IOException {
 		if (patch.patchAvailable()){
 			return new ConcatReader( new Reader[] { linkedFileAsset.getReader(), patch.getReader() });
@@ -71,7 +71,7 @@ public class NamespacedJsSourceModule implements SourceModule {
 			return linkedFileAsset.getReader();
 		}
 	}
-	
+
 	@Override
 	public Reader getReader() throws IOException {
 		try {
@@ -80,14 +80,14 @@ public class NamespacedJsSourceModule implements SourceModule {
 			List<String> staticRequirePaths = getPreExportDefineTimeDependencyCalculator().getRequirePaths(SourceModule.class);
 			String staticRequireAllInvocation = (staticRequirePaths.size() == 0) ? "" : " " + calculateDependenciesRequireDefinition(staticRequirePaths);
 			String defineBlockHeader = CommonJsSourceModule.COMMONJS_DEFINE_BLOCK_HEADER + staticRequireAllInvocation;
-			
-			Reader[] readers = new Reader[] { 
-				new StringReader( String.format(defineBlockHeader, getPrimaryRequirePath()) ), 
+
+			Reader[] readers = new Reader[] {
+				new StringReader( String.format(defineBlockHeader, getPrimaryRequirePath()) ),
 				getUnalteredContentReader(),
 				new StringReader( "\n" ),
 				new StringReader( "module.exports = " + getPrimaryRequirePath().replaceAll("/", ".") + ";" ),
 				new StringReader( requireAllInvocation ),
-				new StringReader(CommonJsSourceModule.COMMONJS_DEFINE_BLOCK_FOOTER), 
+				new StringReader(CommonJsSourceModule.COMMONJS_DEFINE_BLOCK_FOOTER),
 			};
 			return new ConcatReader( readers );
 		}
@@ -95,22 +95,22 @@ public class NamespacedJsSourceModule implements SourceModule {
 			throw new IOException("Unable to create the SourceModule reader", e);
 		}
 	}
-	
+
 	@Override
 	public String getPrimaryRequirePath() {
 		return primaryRequirePath;
 	}
-	
+
 	@Override
 	public boolean isEncapsulatedModule() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isGlobalisedModule() {
 		return true;
 	}
-	
+
 	@Override
 	public List<Asset> getPreExportDefineTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		try {
@@ -120,27 +120,27 @@ public class NamespacedJsSourceModule implements SourceModule {
 			throw new ModelOperationException(e);
 		}
 	}
-	
+
 	@Override
 	public List<Asset> getPostExportDefineTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		try {
 			List<Asset> assets = bundlableNode.assets(this, getPostExportDefineTimeDependencyCalculator().getRequirePaths());
 			assets.addAll(bundlableNode.assets(this, getUseTimeDependencyCalculator().getRequirePaths()));
-			
+
 			return assets;
 		}
 		catch (RequirePathException e) {
 			throw new ModelOperationException(e);
 		}
 	}
-	
+
 	@Override
 	public List<Asset> getUseTimeDependentAssets(BundlableNode bundlableNode) throws ModelOperationException {
 		// Note: use-time NamespacedJs dependencies are promoted to post-export define-time since this makes our transpiler much easier to write,
 		// and since this also enables our CommonJs singleton-pattern to correctly require all of the dependencies needed for any singletons.
 		return Collections.emptyList();
 	}
-	
+
 	private String calculateDependenciesRequireDefinition(List<String> requirePaths) throws ModelOperationException {
 		List<String> requireAllRequirePaths = new ArrayList<>();
 		for (String requirePath : requirePaths) {
@@ -150,44 +150,44 @@ public class NamespacedJsSourceModule implements SourceModule {
 		}
 		return (requireAllRequirePaths.isEmpty()) ? "" : "requireAll(require, ['" + Joiner.on("','").join(requireAllRequirePaths) + "']);\n";
 	}
-	
+
 	@Override
 	public MemoizedFile file()
 	{
 		return linkedFileAsset.file();
 	}
-	
+
 	@Override
 	public String getAssetName() {
 		return linkedFileAsset.getAssetName();
 	}
-	
+
 	@Override
 	public String getAssetPath() {
 		return linkedFileAsset.getAssetPath();
 	}
-	
+
 	private TrieBasedDependenciesCalculator getPreExportDefineTimeDependencyCalculator() {
 		if (trieBasedPreExportDefineTimeDependenciesCalculator == null) {
 			trieBasedPreExportDefineTimeDependenciesCalculator = new TrieBasedDependenciesCalculator(assetContainer, this, new NamespacedJsPreExportDefineTimeDependenciesReader.Factory(this), assetFile, patch.getPatchFile());
 		}
 		return trieBasedPreExportDefineTimeDependenciesCalculator;
 	}
-	
+
 	private TrieBasedDependenciesCalculator getPostExportDefineTimeDependencyCalculator() {
 		if (trieBasedPostExportDefineTimeDependenciesCalculator == null) {
 			trieBasedPostExportDefineTimeDependenciesCalculator = new TrieBasedDependenciesCalculator(assetContainer, this, new NamespacedJsPostExportDefineTimeDependenciesReader.Factory(this), assetFile, patch.getPatchFile());
 		}
 		return trieBasedPostExportDefineTimeDependenciesCalculator;
 	}
-	
+
 	private TrieBasedDependenciesCalculator getUseTimeDependencyCalculator() {
 		if (trieBasedUseTimeDependenciesCalculator == null) {
 			trieBasedUseTimeDependenciesCalculator = new TrieBasedDependenciesCalculator(assetContainer, this, new NamespacedJsUseTimeDependenciesReader.Factory(this), assetFile, patch.getPatchFile());
 		}
 		return trieBasedUseTimeDependenciesCalculator;
 	}
-	
+
 	@Override
 	public List<String> getRequirePaths() {
 		return requirePaths;
@@ -198,20 +198,24 @@ public class NamespacedJsSourceModule implements SourceModule {
 	{
 		return assetContainer;
 	}
-	
+
 	@Override
 	public boolean isScopeEnforced() {
 		return true;
 	}
-	
+
 	@Override
 	public boolean isRequirable()
 	{
 		return true;
 	}
-	
-	public static String calculateRequirePath(String requirePrefix, MemoizedFile file) {
-		return requirePrefix+"/"+file.requirePathName();
+
+	public static String calculateRequirePath(String requirePrefix, MemoizedFile assetFile) {
+		if (assetFile.getName().equals("index.js")) {
+			return requirePrefix;
+		}
+
+		return requirePrefix + "/" + assetFile.requirePathName();
 	}
-	
+
 }

--- a/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/cssresource/CssResourceContentPluginTest.java
+++ b/plugins/brjs-plugins/src/test/java/org/bladerunnerjs/spec/plugin/bundler/cssresource/CssResourceContentPluginTest.java
@@ -10,12 +10,12 @@ import java.util.List;
 import org.bladerunnerjs.api.App;
 import org.bladerunnerjs.api.Aspect;
 import org.bladerunnerjs.api.Blade;
+import org.bladerunnerjs.api.BladeWorkbench;
 import org.bladerunnerjs.api.Bladeset;
+import org.bladerunnerjs.api.BladesetWorkbench;
 import org.bladerunnerjs.api.JsLib;
 import org.bladerunnerjs.api.plugin.ContentPlugin;
 import org.bladerunnerjs.api.spec.engine.SpecTest;
-import org.bladerunnerjs.api.BladesetWorkbench;
-import org.bladerunnerjs.api.BladeWorkbench;
 import org.bladerunnerjs.utility.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 	private File targetDir;
 	private JsLib appLib;
 	private Aspect anotherAspect;
-	
+
 	@Before
 	public void initTestObjects() throws Exception {
 		given(brjs).automaticallyFindsBundlerPlugins()
@@ -55,15 +55,15 @@ public class CssResourceContentPluginTest extends SpecTest {
 			bladeInDefaultBladeset = app.defaultBladeset().blade("b1");
 			targetDir = FileUtils.createTemporaryDirectory( this.getClass() );
 			appLib = app.jsLib("lib");
-		
+
 		binaryResponseFile = FileUtils.createTemporaryFile( this.getClass() );
 		binaryResponse = new FileOutputStream(binaryResponseFile);
 		cssResourcePlugin = brjs.plugins().contentPlugin("cssresource");
 		requestsList = new ArrayList<String>();
 	}
-	
+
 	/* ASPECT LEVEL ASSETS */
-	
+
 	@Test
 	public void assetsInADefaultAspectThemeCanBeRequested() throws Exception
 	{
@@ -73,7 +73,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/aspect_default/theme_myTheme/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInADefaultAspectThemeCanBeRequestedFromWorkbench() throws Exception
 	{
@@ -83,7 +83,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(bladeWorkbench).requestReceivedInDev("cssresource/aspect_default/theme_myTheme/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInADefaultAspectResourcesCanBeRequested() throws Exception
 	{
@@ -93,7 +93,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/aspect_default_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInADefaultAspectAreIncludedInPossibleDevRequests() throws Exception
  	{
@@ -107,7 +107,7 @@ public class CssResourceContentPluginTest extends SpecTest {
         		"cssresource/aspect_default/theme_myTheme/dir1/dir2/someFile.txt"
 		);
  	}
-	
+
 	@Test
 	public void assetsInADefaultAspectAreIncludedInPossibleProdRequests() throws Exception
 	{
@@ -121,7 +121,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 				"cssresource/aspect_default/theme_myTheme/dir1/dir2/someFile.txt"
 		);
 	}
-	
+
 	@Test
 	public void assetsInABladesetThemeCanBeRequested() throws Exception
 	{
@@ -131,7 +131,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/theme_myTheme/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladesetResourcesCanBeRequested() throws Exception
 	{
@@ -141,7 +141,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladesetAreIncludedInPossibleDevRequests() throws Exception
  	{
@@ -155,7 +155,7 @@ public class CssResourceContentPluginTest extends SpecTest {
         		"cssresource/bladeset_bs/theme_myTheme/dir1/dir2/someFile.txt"
 		);
  	}
-	
+
 	@Test
 	public void assetsInABladesetAreIncludedInPossibleProdRequests() throws Exception
 	{
@@ -169,10 +169,10 @@ public class CssResourceContentPluginTest extends SpecTest {
 				"cssresource/bladeset_bs/theme_myTheme/dir1/dir2/someFile.txt"
 		);
 	}
-	
-	
+
+
 	/* BLADE LEVEL ASSETS */
-	
+
 	@Test
 	public void assetsInABladeThemeCanBeRequested() throws Exception
 	{
@@ -184,8 +184,8 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/blade_b1/theme_myTheme/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
-	@Test 
+
+	@Test
 	public void assetsInABladeResourcesCanBeRequested() throws Exception
 	{
 		given(app).hasBeenCreated()
@@ -195,7 +195,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/blade_b1_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladeAreIncludedInPossibleDevRequests() throws Exception
  	{
@@ -210,7 +210,7 @@ public class CssResourceContentPluginTest extends SpecTest {
         		"cssresource/bladeset_bs/blade_b1/theme_myTheme/dir1/dir2/someFile.txt"
 		);
  	}
-	
+
 	@Test
 	public void assetsInABladeAreIncludedInPossibleProdRequests() throws Exception
 	{
@@ -225,7 +225,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 				"cssresource/bladeset_bs/blade_b1/theme_myTheme/dir1/dir2/someFile.txt"
 		);
 	}
-	
+
 	/* WORKBENCH LEVEL ASSETS */
 	@Test
 	public void assetsInABladeWorkbenchThemeCanBeRequested() throws Exception
@@ -237,7 +237,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/blade_b1/workbench/theme_myTheme/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladeWorkbenchResourcesCanBeRequested() throws Exception
 	{
@@ -248,7 +248,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/blade_b1/workbench_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladeWorkbenchAreIncludedInPossibleDevRequests() throws Exception
  	{
@@ -263,7 +263,7 @@ public class CssResourceContentPluginTest extends SpecTest {
         		"cssresource/bladeset_bs/blade_b1/workbench/theme_myTheme/dir1/dir2/someFile.txt"
 		);
  	}
-	
+
 	@Test
 	public void assetsInABladeWorkbenchAreNotIncludedInPossibleProdAspectRequests() throws Exception
 	{
@@ -278,7 +278,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 				"cssresource/bladeset_bs/blade_b1/workbench/theme_myTheme/dir1/dir2/someFile.txt"
 		);
 	}
-	
+
 	@Test
 	public void assetsInABladesetWorkbenchResourcesCanBeRequested() throws Exception
 	{
@@ -288,7 +288,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/bladeset_bs/workbench_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABladesetWorkbenchAreNotIncludedInPossibleProdAspectRequests() throws Exception
 	{
@@ -302,7 +302,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 				"cssresource/bladeset_bs/workbench/theme_myTheme/dir1/dir2/someFile.txt"
 		);
 	}
-	
+
 	//TODO: not sure about the request URL - that is what is sent from the browser but other tests only
 	// seem to use a part of the URL. I guess this way is prone to brittleness
 	// But surely we want to test the actual URLs sent from the browser ????
@@ -316,9 +316,9 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(app).requestReceived("bs1/b1/workbench/v/dev/cssresource/aspect_default/theme_common/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	/* LIBRARY LEVEL ASSETS */
-	
+
 	@Test
 	public void assetsInAnSDKLibraryCanBeRequested() throws Exception
 	{
@@ -328,7 +328,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInAnSDKLibraryCanBeRequestedFromAWorkbenchScope() throws Exception
 	{
@@ -338,7 +338,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(bladeWorkbench).requestReceivedInDev("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsCanHaveAEncodedSpaceInTheirPath() throws Exception
 	{
@@ -348,7 +348,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(bladeWorkbench).requestReceivedInDev("cssresource/lib_sdkLib/resources/some%20dir/another%20dir/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void imagesArentCorrupt() throws Exception
 	{
@@ -358,17 +358,18 @@ public class CssResourceContentPluginTest extends SpecTest {
     	when(aspect).requestReceivedInDev("cssresource/aspect_default_resource/resources/br-logo.png", binaryResponse);
     	then(binaryResponseFile).sameAsFile("src/test/resources/br-logo.png");
 	}
-	
+
 	@Test
 	public void assetsInABRSDKLibraryAreAvailableInDev() throws Exception
 	{
 		given(app).hasBeenCreated()
 			.and(aspect).hasBeenCreated()
+			.and(sdkJsLib).hasClass("index")
 			.and(aspect).indexPageRequires(sdkJsLib)
 			.and(sdkJsLib).containsResourceFileWithContents("dir1/dir2/someFile.txt", "someFile.txt contents");
 		then(aspect).devRequestsForContentPluginsAre("cssresource", "cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt, cssresource/aspect_default_resource/index.html");
 	}
-	
+
 	@Test
 	public void assetsInBRSdkLibraryInDevHaveCorrectContent() throws Exception
 	{
@@ -378,7 +379,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInABRSDKLibraryAreAvailableInProd() throws Exception
 	{
@@ -387,7 +388,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		.and(sdkJsLib).containsResourceFileWithContents("dir1/dir2/someFile.txt", "someFile.txt contents");
 		then(aspect).prodRequestsForContentPluginsAre("cssresource", "cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt");
 	}
-	
+
 	@Test
 	public void assetsInABRSdkLibraryInProdHaveCorrectContent() throws Exception
 	{
@@ -396,8 +397,8 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(sdkJsLib).containsResourceFileWithContents("dir1/dir2/someFile.txt", "someFile.txt contents");
 		when(aspect).requestReceivedInProd("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
-	}	
-	
+	}
+
 	@Test
 	public void assetsInAThirdpartySDKLibraryAreAvailableInDev() throws Exception
 	{
@@ -405,10 +406,10 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(aspect).hasBeenCreated()
 			.and(sdkJsLib).containsResourceFileWithContents("dir1/dir2/someFile.txt", "someFile.txt contents")
 			.and(sdkJsLib).containsFileWithContents("thirdparty-lib.manifest", "depends:");
-		then(aspect).devRequestsForContentPluginsAre("cssresource", 
+		then(aspect).devRequestsForContentPluginsAre("cssresource",
 				"cssresource/lib_sdkLib/thirdparty-lib.manifest, cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt");
 	}
-	
+
 	@Test
 	public void assetsInAThirdpartySdkLibraryInDevHaveCorrectContent() throws Exception
 	{
@@ -419,7 +420,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInDev("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInAThirdpartySDKLibraryAreAvailableInProd() throws Exception
 	{
@@ -428,10 +429,10 @@ public class CssResourceContentPluginTest extends SpecTest {
 		.and(aspect).indexPageRequires(sdkJsLib)
 		.and(sdkJsLib).containsResourceFileWithContents("dir1/dir2/someFile.txt", "someFile.txt contents")
 		.and(sdkJsLib).containsFileWithContents("thirdparty-lib.manifest", "depends:");
-		then(aspect).prodRequestsForContentPluginsAre("cssresource", 
+		then(aspect).prodRequestsForContentPluginsAre("cssresource",
 				"cssresource/aspect_default_resource/index.html", "cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", "cssresource/lib_sdkLib/thirdparty-lib.manifest");
 	}
-	
+
 	@Test
 	public void assetsInAThirdpartySdkLibraryInProdHaveCorrectContent() throws Exception
 	{
@@ -442,7 +443,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInProd("cssresource/lib_sdkLib/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInDefaultBladesetBladeCanBeRequested() throws Exception
 	{
@@ -452,7 +453,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(aspect).requestReceivedInProd("cssresource/bladeset_default/blade_b1_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void assetsInDefaultAspectCanBeRequested() throws Exception
 	{
@@ -462,7 +463,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		when(defaultAspect).requestReceivedInProd("cssresource/aspect_default_resource/resources/dir1/dir2/someFile.txt", response);
 		then(response).textEquals("someFile.txt contents");
 	}
-	
+
 	@Test
 	public void pathsIgnoredViaConfigAreNotServed() throws Exception {
 		given(app).hasBeenCreated()
@@ -474,7 +475,7 @@ public class CssResourceContentPluginTest extends SpecTest {
     		.and(aspect).devRequestsForContentPluginsAre("cssresource", "")
     		.and(exceptions).verifyException(FileNotFoundException.class, "apps/app1/resources/.git");
 	}
-	
+
 	@Test
 	public void pathsInJsLibsIgnoredViaConfigAreNotServed() throws Exception {
 		given(app).hasBeenCreated()
@@ -486,7 +487,7 @@ public class CssResourceContentPluginTest extends SpecTest {
     		.and(aspect).devRequestsForContentPluginsAre("cssresource", "cssresource/aspect_default_resource/index.html")
     		.and(exceptions).verifyException(FileNotFoundException.class, "sdk/libs/javascript/sdkLib/.git");
 	}
-	
+
 	@Test // This is to protect against .less or .sass files referencing the file where we wont detect it
 	public void cssResourcesWithCommonExtensionsAreIncludedInContentPathsEvenIfTheyArentUsed() throws Exception {
 		given(defaultAspect).indexPageHasContent("")
@@ -498,20 +499,20 @@ public class CssResourceContentPluginTest extends SpecTest {
 			)
 			.and(brjs).localeSwitcherHasContents("")
 			.and(brjs).hasVersion("1234");
-		then(defaultAspect).usedProdContentPathsForPluginsAre("cssresource", 
+		then(defaultAspect).usedProdContentPathsForPluginsAre("cssresource",
 				"cssresource/aspect_default/theme_common/unusedFile.gif",
 				"cssresource/aspect_default/theme_common/unusedFile.jpeg",
 			"cssresource/aspect_default/theme_common/unusedFile.jpg",
 			"cssresource/aspect_default/theme_common/unusedFile.png"
 		);
 	}
-	
+
 	@Test
 	public void cssResourcesInBrLibsWithCommonExtensionsAreIncludedInContentPathsEvenIfTheyArentUsed() throws Exception {
 		given(appLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib")
     		.and(appLib).containsFileWithContents("src/Class.js", "BR Lib")
     		.and(appLib).containsFiles(
-				"themes/common/usedFile.png", "themes/common/images/usedFile.png", 
+				"themes/common/usedFile.png", "themes/common/images/usedFile.png",
 				"themes/common/unusedFile.png", "themes/common//images/unusedFile.png"
     		)
     		.and(defaultAspect).indexPageHasContent("require('lib/Class')")
@@ -521,12 +522,12 @@ public class CssResourceContentPluginTest extends SpecTest {
     	then(targetDir).containsFile("v/1234/cssresource/lib_lib/themes/common/unusedFile.png")
     		.and(targetDir).containsFile("v/1234/cssresource/lib_lib/themes/common/images/unusedFile.png");
 	}
-	
+
 	@Test
 	public void cssResourcesInThirdpartyLibsWithCommonExtensionsAreIncludedInContentPathsEvenIfTheyArentUsed() throws Exception {
 		given(appLib).containsFileWithContents("thirdparty-lib.manifest", "css: \"**/*.css\"\n"+"exports: null")
 			.and(appLib).containsFileWithContents("src.js", "Thirdparty Lib")
-			.and(appLib).containsFiles( 
+			.and(appLib).containsFiles(
 				"unusedFile.png", "myCoolStyles/unusedFile.png", "myCoolStyles/images/unusedFile.png"
 			)
 			.and(defaultAspect).indexPageHasContent("require('lib')")
@@ -537,7 +538,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(targetDir).containsFile("v/1234/cssresource/lib_lib/myCoolStyles/unusedFile.png")
 			.and(targetDir).containsFile("v/1234/cssresource/lib_lib/myCoolStyles/images/unusedFile.png");
 	}
-	
+
 	@Test
 	public void onlyCssResourceBundlesUsedFromCssFilesAreReturnedAsContentPaths() throws Exception {
 		given(defaultAspect).indexPageHasContent("")
@@ -547,7 +548,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(brjs).hasVersion("1234");
 		then(defaultAspect).usedProdContentPathsForPluginsAre("cssresource", "cssresource/aspect_default/theme_common/usedFile.ext", "cssresource/aspect_default_resource/resources/css/usedFile.ext");
 	}
-	
+
 	@Test
 	public void cssResourcesUsedInIndexPagesShouldBeIncludedInFilteredContentPaths() throws Exception {
 		given(defaultAspect).indexPageHasContent(".style { background:url('v/1234/cssresource/aspect_default_resource/resources/css/usedFile.ext') }")
@@ -556,7 +557,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(brjs).hasVersion("1234");
 		then(defaultAspect).usedProdContentPathsForPluginsAre("cssresource", "cssresource/aspect_default_resource/resources/css/usedFile.ext");
 	}
-	
+
 	@Test
 	public void onlyCssResourceBundlesUsedFromCssFilesArePresentInTheBuiltArtifact() throws Exception {
 		given(defaultAspect).indexPageHasContent("")
@@ -571,18 +572,18 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(targetDir).doesNotContainFile("v/1234/cssresource/aspect_default_resource/resources/some-dir/unusedFile.ext")
 			.and(targetDir).doesNotContainFile("v/1234/cssresource/aspect_default/theme_common/style.css");
 	}
-	
+
 	@Test
 	public void cssResourcesInBrLibsAreIncludedInTheBuiltArtifact() throws Exception {
 		given(appLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib")
     		.and(appLib).containsFileWithContents("src/Class.js", "BR Lib")
-    		.and(appLib).containsFileWithContents("themes/common/styles.css", 
+    		.and(appLib).containsFileWithContents("themes/common/styles.css",
     			".style { background:url('../usedFile.ext'); }\n"+
     			".style { background:url('usedFile.ext'); }\n"+
     			".style { background:url('images/usedFile.ext'); }\n"
     		)
     		.and(appLib).containsFiles(
-				"themes/common/usedFile.ext", "themes/common/images/usedFile.ext", 
+				"themes/common/usedFile.ext", "themes/common/images/usedFile.ext",
 				"themes/common/unusedFile.ext", "themes/common//images/unusedFile.ext"
     		)
     		.and(defaultAspect).indexPageHasContent("require('lib/Class')")
@@ -594,18 +595,18 @@ public class CssResourceContentPluginTest extends SpecTest {
     		.and(targetDir).doesNotContainFile("v/1234/cssresource/lib_lib/themes/common/unusedFile.ext")
     		.and(targetDir).doesNotContainFile("v/1234/cssresource/lib_lib/themes/common/images/unusedFile.ext");
 	}
-	
+
 	@Test
 	public void cssResourcesInThirdpartyLibsAreIncludedInTheBuiltArtifact() throws Exception {
 		given(appLib).containsFileWithContents("thirdparty-lib.manifest", "css: \"**/*.css\"\n"+"exports: null")
 			.and(appLib).containsFileWithContents("src.js", "Thirdparty Lib")
-			.and(appLib).containsFileWithContents("myCoolStyles/styles.css", 
+			.and(appLib).containsFileWithContents("myCoolStyles/styles.css",
 				".style { background-image: url('../usedFile.ext'); }\n"+
 				".style { background-image: url('usedFile.ext'); }\n"+
 				".style { background-image: url('images/usedFile.ext'); }\n"
 			)
 			.and(appLib).containsFiles(
-				"usedFile.ext", "myCoolStyles/usedFile.ext", "myCoolStyles/images/usedFile.ext", 
+				"usedFile.ext", "myCoolStyles/usedFile.ext", "myCoolStyles/images/usedFile.ext",
 				"unusedFile.ext", "myCoolStyles/unusedFile.ext", "myCoolStyles/images/unusedFile.ext"
 			)
 			.and(defaultAspect).indexPageHasContent("require('lib')")
@@ -619,18 +620,18 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(targetDir).doesNotContainFile("v/1234/cssresource/lib_lib/myCoolStyles/unusedFile.ext")
 			.and(targetDir).doesNotContainFile("v/1234/cssresource/lib_lib/myCoolStyles/images/unusedFile.ext");
 	}
-	
+
 	@Test
 	public void cssResourcesInBrLibsAreIncludedInTheBuiltArtifactWhenReferencedFromANonDefaultAspect() throws Exception {
 		given(appLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib")
     		.and(appLib).containsFileWithContents("src/Class.js", "BR Lib")
-    		.and(appLib).containsFileWithContents("themes/common/styles.css", 
+    		.and(appLib).containsFileWithContents("themes/common/styles.css",
     			".style { background:url('../usedFile.ext'); }\n"+
     			".style { background:url('usedFile.ext'); }\n"+
     			".style { background:url('images/usedFile.ext'); }\n"
     		)
     		.and(appLib).containsFiles(
-				"themes/common/usedFile.ext", "themes/common/images/usedFile.ext", 
+				"themes/common/usedFile.ext", "themes/common/images/usedFile.ext",
 				"themes/common/unusedFile.ext", "themes/common//images/unusedFile.ext"
     		)
     		.and(anotherAspect).indexPageHasContent("require('lib/Class')")
@@ -642,18 +643,18 @@ public class CssResourceContentPluginTest extends SpecTest {
     		.and(targetDir).doesNotContainFile("another/v/1234/cssresource/lib_lib/themes/common/unusedFile.ext")
     		.and(targetDir).doesNotContainFile("another/v/1234/cssresource/lib_lib/themes/common/images/unusedFile.ext");
 	}
-	
+
 	@Test
 	public void cssResourcesInThirdpartyLibsAreIncludedInTheBuiltArtifactWhenReferencedFromANonDefaultAspect() throws Exception {
 		given(appLib).containsFileWithContents("thirdparty-lib.manifest", "css: \"**/*.css\"\n"+"exports: null")
 			.and(appLib).containsFileWithContents("src.js", "Thirdparty Lib")
-			.and(appLib).containsFileWithContents("myCoolStyles/styles.css", 
+			.and(appLib).containsFileWithContents("myCoolStyles/styles.css",
 				".style { background-image: url('../usedFile.ext'); }\n"+
 				".style { background-image: url('usedFile.ext'); }\n"+
 				".style { background-image: url('images/usedFile.ext'); }\n"
 			)
 			.and(appLib).containsFiles(
-				"usedFile.ext", "myCoolStyles/usedFile.ext", "myCoolStyles/images/usedFile.ext", 
+				"usedFile.ext", "myCoolStyles/usedFile.ext", "myCoolStyles/images/usedFile.ext",
 				"unusedFile.ext", "myCoolStyles/unusedFile.ext", "myCoolStyles/images/unusedFile.ext"
 			)
 			.and(anotherAspect).indexPageHasContent("require('lib')")
@@ -667,12 +668,12 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(targetDir).doesNotContainFile("another/v/1234/cssresource/lib_lib/myCoolStyles/unusedFile.ext")
 			.and(targetDir).doesNotContainFile("another/v/1234/cssresource/lib_lib/myCoolStyles/images/unusedFile.ext");
 	}
-	
+
 	@Test
 	public void nestedCssResourcesInThirdpartyLibsThatLiveInADirectoryWithTheSameNameAsAnotherAreIncludedInTheBuiltApp() throws Exception {
 		given(appLib).containsFileWithContents("thirdparty-lib.manifest", "css: \"**/*.css\"\n"+"exports: null")
 			.and(appLib).containsFileWithContents("src.js", "Thirdparty Lib")
-			.and(appLib).containsFileWithContents("styles.css", 
+			.and(appLib).containsFileWithContents("styles.css",
 				".style { background-image: url('dir1/foo/images/usedFile.ext'); }\n"+
 				".style { background-image: url('dir2/foo/images/usedFile.ext'); }\n"
 			)
@@ -686,7 +687,7 @@ public class CssResourceContentPluginTest extends SpecTest {
 		then(targetDir).containsFile("v/1234/cssresource/lib_lib/dir1/foo/images/usedFile.ext")
 			.and(targetDir).containsFile("v/1234/cssresource/lib_lib/dir2/foo/images/usedFile.ext");
 	}
-	
+
 	@Test // test for https://github.com/BladeRunnerJS/brjs/issues/1443 - "'themes' dirs in libs cause `request form name 'null' hasn't been registered` when building apps"
 	public void filesInsideLibThemesAreSupported() throws Exception {
 		given(appLib).containsFileWithContents("br-lib.conf", "requirePrefix: lib")
@@ -695,9 +696,9 @@ public class CssResourceContentPluginTest extends SpecTest {
 			.and(appLib).containsFileWithContents("themes/myTheme/cssResource.txt", "themes/myTheme/cssResource.txt")
 			.and(defaultAspect).indexPageHasContent("require('lib/Class')");
 		when(defaultAspect).requestReceivedInProd("cssresource/lib_lib/themes/myTheme/cssResource.txt", response);
-		then(aspect).prodAndDevRequestsForContentPluginsAre("cssresource", 
+		then(aspect).prodAndDevRequestsForContentPluginsAre("cssresource",
 				"cssresource/lib_lib/br-lib.conf", "cssresource/lib_lib/themes/myTheme/cssResource.txt")
 			.and(response).containsText("themes/myTheme/cssResource.txt");
 	}
-	
+
 }


### PR DESCRIPTION
Part of the brjs-ify work (converting node style libs -> brjs conformant libs), adds facility to require the index js file from within a brjs conformant lib.