### PR TITLE
Remove 32-bit compatibility support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ addons:
   apt:
     packages:
     - libgd2-xpm
-    - ia32-libs
-    - ia32-libs-multiarch
 before_install:
 - export JAVA7_HOME=/usr/lib/jvm/java-7-oracle
 - export JAVA8_HOME=/usr/lib/jvm/java-8-oracle


### PR DESCRIPTION
We now make 64-bit Linux browsers available, so we should be using these
on Travis.