### PR TITLE
Update Travis chat notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,4 @@ script:
 - TERM=dumb ./gradlew testJava
 - TERM=dumb ./gradlew :brjs-sdk:testFirefox
 notifications:
-  slack: caplin:jbsT4IpvMOU6YGaDoZdz9P3f
-  hipchat:
-    rooms:
-      secure: kCMCO2aez+lZZtBi1g4O3z92teXx2rxifVWgwwTloE/Oyi8t3+NPu7932QOg1ZlHiIFRh9ncSsM00y/gN3pp1f6Q7nm+5UxFflTHqTRrrsHe0Tgjj+bl86yGjoY4KWEhuNq9rxEo7ciMB5aYcXEeGVc34XghUaa/3FNQWg2NArA=
+  slack: caplin:EoB4AYFg5wBGCYEJc7Z1kNZz


### PR DESCRIPTION
Travis chat notifications are now being emitted to the #ct channel
rather than the #brjs channel. Also disabled chat notifications for
HipChat, which we no longer use.