### PR TITLE
feat: Allow i18n messages to be registered with i18n Translator

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/I18N.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/I18N.js
@@ -76,6 +76,10 @@ I18N.create = function(translator) {
 		translator.setLocale(locale);
 	};
 
+	i18n.registerTranslations = function(locale, translations) {
+		translator.registerTranslations(locale, translations);
+	};
+
 	return i18n;
 };
 

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -20,12 +20,12 @@ var TEST_DATE_FORMAT_LONG = "D, d M, Y, h:i:s A";
 /**
 * @class
 * @alias module:br/i18n/Translator
-* 
+*
 * @classdesc
 * <p>The class within the <code>br.I18N</code> package that is responsible
 * for translating localization tokens in the form of
 * <code>&#64;{key.name}</code> into translated text.</p>
-* 
+*
 * <p>This class should not be instantiated directly. To access i18n functions
 * use the [br/i18n]{@link module:br/i18n} class which returns the
 * [br/i18n/I18N]{@link module:br/i18n/I18N} accessor class.
@@ -51,6 +51,20 @@ function Translator(messageDefinitions, useLocale) {
 
 Translator.MESSAGES = {
 	UNTRANSLATED_TOKEN_LOG_MSG: 'A translation has not been provided for the i18n key "{0}" in the "{1}" locale'
+};
+
+Translator.prototype.registerTranslations = function(locale, translations) {
+	for (var token in translations) {
+		var lowerCasedToken = token.toLowerCase();
+
+		if (this.messageDefinitions[locale][lowerCasedToken] === undefined) {
+			this.messageDefinitions[locale][lowerCasedToken] = translations[token];
+		}
+
+		if (this.locale === locale && this.messages[lowerCasedToken] === undefined) {
+			this.messages[lowerCasedToken] = translations[token];
+		}
+	}
 };
 
 Translator.prototype.setLocale = function(locale) {

--- a/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/test-unit/tests/TranslatorTest.js
@@ -9,7 +9,7 @@
 	TranslatorTest.prototype.setUp = function() {
 		JsHamcrest.Integration.JsTestDriver();
 		JsMockito.Integration.JsTestDriver();
-		
+
 		this.subrealm = realm.subrealm();
 		this.subrealm.install();
 
@@ -20,17 +20,17 @@
 		});
 
 		fell.configure("warn", {}, [store]);
-		
+
 		var oThis = this;
 		define('br/I18n/LocalisedTime', function(require, exports, module) {
 			var MockLocalisedTime = function() {};
 			MockLocalisedTime.prototype.format = function() { return "LocalisedTime.format"; };
-			
+
 			module.exports = MockLocalisedTime;
 		});
 
 		require('service!br.app-meta-service').setVersion('1.2.3');
-		
+
 		this.messages = {
 			'defaultValue' : {
 				"caplin.test.key": "default value for test key",
@@ -93,7 +93,7 @@
 				"currency.amd.issuer": "Armenia",
 				"currency.amd.name": "Drams"
 		}};
-		
+
 		this.camelCaseTokens = {
 			'locale' : {
 				"token.CamelcasetokeN": "a Translation"
@@ -295,7 +295,7 @@
 
 		assertEquals(oTranslator.getMessage(sKey, {}), sExpected);
 	};
-	
+
 	TranslatorTest.prototype.test_getMessageForAnUnknownKeyThrowsAnErrorInProd = function()
 	{
 		var sKey = "unknown.key";
@@ -304,7 +304,7 @@
 
 		var Translator = require('br/i18n/Translator');
 		var oTranslator = new Translator({});
-		
+
 		assertEquals(oTranslator.getMessage(sKey, {}), sExpected);
 	};
 
@@ -410,5 +410,34 @@
 		assertEquals(translator.parseNumber('1,000.50'), 1000.50);
 		assertEquals(translator.parseNumber('1000.50'), 1000.50);
 		assertEquals(translator.parseNumber('1,000,000'), 1000000);
+	};
+
+	TranslatorTest.prototype.test_registerTranslations = function() {
+		var translations = {
+			key: 'value',
+			upperCaseKey: 'Value'
+		};
+		var Translator = require('br/i18n/Translator');
+		var translator = new Translator(this.i18nTimeDateNumberMessages, 'locale');
+
+		translator.registerTranslations('locale', translations);
+
+		assertEquals(translator.getMessage('key'), 'value');
+		assertEquals(translator.getMessage('upperCaseKey'), 'Value');
+
+		return translator;
+	};
+
+	TranslatorTest.prototype.test_registerTranslationsDoesNotAllowOverridingMessages = function() {
+		var translations = {
+			key: 'newvalue',
+			upperCaseKey: 'newValue'
+		};
+		var translator = this.test_registerTranslations();
+
+		translator.registerTranslations('locale', translations);
+
+		assertEquals(translator.getMessage('key'), 'value');
+		assertEquals(translator.getMessage('upperCaseKey'), 'Value');
 	};
 })();


### PR DESCRIPTION
cc @bit-shifter @thecapdan 

The webpack caplin i18n loader registers i18n tokens on load up so we need to provide a mechanism in the Translator class to support this approach.