### PR TITLE
Add debug option to brjs serve

### DIFF
--- a/brjs-sdk/sdk/brjs
+++ b/brjs-sdk/sdk/brjs
@@ -32,5 +32,11 @@ if [ $? -eq 0 ]; then
 	fi
 else
 	# UNIX & older GitBash versions
-	java $JAVA_OPTS -cp "$BRJS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"
+	if [ $1 = "debug" ]
+	then
+		shift
+		java $JAVA_OPTS -cp "$BRJS_CLASSPATH" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"
+	else
+		java $JAVA_OPTS -cp "$BRJS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"
+	fi
 fi

--- a/brjs-sdk/sdk/brjs
+++ b/brjs-sdk/sdk/brjs
@@ -25,7 +25,11 @@ uname -a | grep -E "(^CYGWIN|^MINGW32.*Msys$)" > /dev/null
 if [ $? -eq 0 ]; then
 	# Cygwin & newer GitBash versions
 	PWD=`pwd`
-	java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`cygpath -wp $PWD`" "$@"
+	if [ $1 == "debug" ]; then
+		java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`cygpath -wp $PWD`" "${@:2}"
+	else
+		java $JAVA_OPTS -cp "`cygpath -wp $BRJS_CLASSPATH`" org.bladerunnerjs.runner.CommandRunner "`cygpath -wp $SCRIPT_DIR`" "`cygpath -wp $PWD`" "$@"
+	fi
 else
 	# UNIX & older GitBash versions
 	java $JAVA_OPTS -cp "$BRJS_CLASSPATH" org.bladerunnerjs.runner.CommandRunner "$SCRIPT_DIR" "`pwd`" "$@"

--- a/brjs-sdk/sdk/brjs.cmd
+++ b/brjs-sdk/sdk/brjs.cmd
@@ -17,7 +17,6 @@ echo Please install Java 7 or Java 8 and ensure it's available on the PATH.
 echo You can find more information about how to do this at 'http://bladerunnerjs.org/docs/use/install/'.
 exit /B 1
 
-
 :runBrjs
 set THIS_DIR=%CD%
 set THIS_DIR=%THIS_DIR:\=/%
@@ -30,4 +29,9 @@ FOR /F "delims=" %%I in ('echo %filename%') do set SHORT_SCRIPT_DIR=%%~sI
 cd %THIS_DIR%
 set BRJS_CLASSPATH="%SCRIPT_DIR%/libs/java/system/*;%SCRIPT_DIR%/../conf/java/*;"
 
-java %JAVA_OPTS% -cp %BRJS_CLASSPATH% org.bladerunnerjs.runner.CommandRunner "%SCRIPT_DIR%" "%THIS_DIR%" %*
+IF "%1"=="debug" (
+	for /f "tokens=1,* delims= " %%a in ("%*") do set ALL_ARGS_BUT_FIRST=%%b
+	java %JAVA_OPTS% -cp %BRJS_CLASSPATH% -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n org.bladerunnerjs.runner.CommandRunner "%SCRIPT_DIR%" "%THIS_DIR%" %ALL_ARGS_BUT_FIRST%
+	) ELSE (
+	java %JAVA_OPTS% -cp %BRJS_CLASSPATH% org.bladerunnerjs.runner.CommandRunner "%SCRIPT_DIR%" "%THIS_DIR%" %*
+	)


### PR DESCRIPTION
This change in the brjs script allows the option to debug the java code of brjs by using `brjs debug serve`, which is can be useful at times.

I have made it work with intelliJ on windows using [this](https://www.linkedin.com/pulse/debug-jar-files-intellij-idea-maksym-lushpenko) tutorial. It might need testing on other OS.

<!---
@huboard:{"order":1698.5,"milestone_order":1689,"custom_state":""}
-->
