### PR TITLE
fix: Register a translation without predeclaring its locale

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-i18n/src/br/i18n/Translator.js
@@ -54,6 +54,10 @@ Translator.MESSAGES = {
 };
 
 Translator.prototype.registerTranslations = function(locale, translations) {
+	if (this.messageDefinitions[locale] === undefined) {
+		this.messageDefinitions[locale] = {};
+	}
+
 	for (var token in translations) {
 		var lowerCasedToken = token.toLowerCase();
 


### PR DESCRIPTION
Previously the user would need to predeclare the locales that would be
registered (for example in the index.html page). This is annoying when
testing code that requires translations or when testing in node.

closes: CTNXT-26