### PR TITLE
fix: Remove dynamic require from AliasRegistryClass

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br/src/br/AliasRegistryClass.js
+++ b/brjs-sdk/sdk/libs/javascript/br/src/br/AliasRegistryClass.js
@@ -6,6 +6,7 @@
 
 var br = require('br/Core');
 var Errors = require('./Errors');
+var dynamicRefRequire = require('br/dynamicRefRequire');
 
 /**
 * @class
@@ -137,7 +138,7 @@ AliasRegistryClass.prototype._getClassRef = function(aliasName) {
 	var alias = this._aliasData[aliasName];
 
 	if(alias.classRef === undefined) {
-		alias.classRef = require(alias["class"]);
+		alias.classRef = dynamicRefRequire(alias["class"]);
 	}
 
 	return alias.classRef;
@@ -151,7 +152,7 @@ AliasRegistryClass.prototype._getInterfaceRef = function(aliasName) {
 
 	if(alias.interfaceRef === undefined) {
 		var interfaceName = alias['interface'];
-		alias.interfaceRef = (interfaceName) ? require(interfaceName) : null;
+		alias.interfaceRef = (interfaceName) ? dynamicRefRequire(interfaceName) : null;
 	}
 
 	return alias.interfaceRef;

--- a/brjs-sdk/sdk/libs/javascript/br/src/br/dynamicRefRequire.js
+++ b/brjs-sdk/sdk/libs/javascript/br/src/br/dynamicRefRequire.js
@@ -1,0 +1,7 @@
+
+// Extracting the dynamic require as it causes problems in webpack.
+// When the dynamic require is in a separate module we can configure webpack
+// to load another module instead of this module.
+module.exports = function(ref) {
+	return require(ref);
+}


### PR DESCRIPTION
Allows us to prevent the webpack bundling errors around `AliasRegistryClass`.

closes: CTNXT-193