### PR TITLE
Protect from an exception on writing to readonly property

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/keyboard-event/keyboard-event.js
+++ b/brjs-sdk/sdk/libs/javascript/keyboard-event/keyboard-event.js
@@ -54,7 +54,11 @@
 
     // chrome polyfill
     if(evt.keyIdentifier) {
-      evt.key = evt.keyIdentifier;
+      try {
+        evt.key = evt.keyIdentifier;
+      } catch(e) {
+        // read-only in chrome 51+
+      }
     }
 
     return evt;


### PR DESCRIPTION
KeyboardEvent.key has been implemented in Chrome 51+ and it is readonly
http://caniuse.com/#feat=keyboardevent-key
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#Browser_compatibility
https://bugs.chromium.org/p/chromium/issues/detail?id=227231

Attempts to modify this property now result in an exception:
`TypeError: Cannot assign to read only property 'key' of object '#<KeyboardEvent>'`