### PR TITLE
fix(br-validation): Separate require from constuction of `ValidationR…

### DIFF
--- a/brjs-sdk/sdk/libs/javascript/br-validation/src/ISODateValidator.js
+++ b/brjs-sdk/sdk/libs/javascript/br-validation/src/ISODateValidator.js
@@ -66,7 +66,8 @@ ISODateValidator.prototype.validate = function(value, mAttributes, validationRes
  * @type Boolean
  */
 ISODateValidator.prototype.isValidISODate = function (ISODateString) {
-	var validationResult = new require("br/validation/ValidationResult")();
+	var ValidationResult = require("br/validation/ValidationResult");
+	var validationResult = new ValidationResult();
 	this.validate(ISODateString, {}, validationResult);
 	return validationResult.isValid();
 };


### PR DESCRIPTION
…esult`

Inlining the two causes webpack to complain about not being able to statically analyze
the require.

closes: CTNXT-278